### PR TITLE
Add the function to measure memory access in feed-forward inference.

### DIFF
--- a/torchmeter/engine.py
+++ b/torchmeter/engine.py
@@ -9,13 +9,13 @@ import torch.nn as nn
 from rich.tree import Tree
 
 from torchmeter.utils import dfs_task, Verboser
-from torchmeter.statistic import ParamsMeter, CalMeter
+from torchmeter.statistic import ParamsMeter, CalMeter, MemMeter
 
 __all__ = ('OperationNode', 'OperationTree')
 
 class OperationNode:
    
-    statistics:Tuple[str] = ('param', 'cal') # all statistics stored as attributes
+    statistics:Tuple[str] = ('param', 'cal', 'mem') # all statistics stored as attributes
 
     def __init__(self, 
                  module:nn.Module,
@@ -54,6 +54,7 @@ class OperationNode:
         # statistic info (all read-only)
         self.__param = ParamsMeter(opnode=self)
         self.__cal = CalMeter(opnode=self)
+        self.__mem = MemMeter(opnode=self)
 
         # other info
         for key, value in kwargs.items():
@@ -69,6 +70,10 @@ class OperationNode:
     @property
     def cal(self) -> CalMeter:
         return self.__cal
+
+    @property
+    def mem(self) -> MemMeter:
+        return self.__mem
 
     def __copy__(self):
         new_obj = OperationNode(self.operation)

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from enum import IntFlag, unique
+from enum import IntEnum, unique
 from collections import namedtuple
 from abc import ABC, abstractmethod
 from operator import attrgetter, mul
@@ -10,11 +10,11 @@ import torch.nn as nn
 OPN_TYPE = TypeVar("OperationNode")
 
 @unique
-class Unit(IntFlag):
-    T:int = 2**40
-    G:int = 2**30
-    M:int = 2**20
-    K:int = 2**10
+class Unit(IntEnum):
+    T:int = 1e12
+    G:int = 1e9
+    M:int = 1e6
+    K:int = 1e3
 
 def auto_unit(val:Union[int, float], suffix:str='') -> str:
     for unit in list(Unit):

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -1,5 +1,5 @@
 from functools import reduce
-from enum import IntEnum, unique
+from enum import IntEnum, IntFlag, unique
 from collections import namedtuple
 from abc import ABC, abstractmethod
 from operator import attrgetter, mul
@@ -10,16 +10,22 @@ import torch.nn as nn
 OPN_TYPE = TypeVar("OperationNode")
 
 @unique
-class Unit(IntEnum):
+class DecimalUnit(IntEnum):
     T:int = 1e12
     G:int = 1e9
     M:int = 1e6
     K:int = 1e3
 
-def auto_unit(val:Union[int, float], suffix:str='') -> str:
-    for unit in list(Unit):
+class BinaryUnit(IntFlag):
+    TiB:int = 2**40
+    GiB:int = 2**30
+    MiB:int = 2**20
+    KiB:int = 2**10
+
+def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> str:
+    for unit in list(unit_system):
         if val >= unit:
-            return f'{val / unit:.2f} {unit.name + suffix}'
+            return f'{val / unit:.2f} {unit.name}'
 
 class UpperLinkData:
 

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Iterable, List, Optional, Tuple
 def perfect_savepath(origin_path:str, 
                      target_ext:Optional[str],
                      default_filename:str='Data'):
+    origin_path = os.path.abspath(origin_path)
     dir, file = os.path.split(origin_path)
     if '.' in file: # specify a file path
         os.makedirs(dir, exist_ok=True)


### PR DESCRIPTION
## 📋 Summary

> [!IMPORTANT]
> - [ ] This PR fixes an issue. [Link]() <!--Link to related issues if applicable -->    
> - [x] This PR adds something new.
> - [ ] This PR is **not** a code change (e.g. `README`, typos, ...)
> - [ ] This PR has been tested.

<!-- What is this pull request for? Does it fix any issues? -->

## 📝 Changes

<!-- Describe what you change and what the purpose in this pull request. -->

<details>
<summary>Details</summary>

- `torchmeter/core.py`: add `mem` property to `Meter` class to get the report of model memory access situation. 
- `torchmeter/engine.py`: add `mem` property to `OperationNode`.
- `torchmeter/statistic.py`: add memory measurement logit, i.e. the `MemMeter` class. By the way, fix the bug of missing units.
- `torchmeter/utils.py`: fix the bug that using relative path to save the report table.

</details>