### PR TITLE
Realize front-rear separation in tabel rendering and saving

### DIFF
--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -324,14 +324,14 @@ if __name__ == '__main__':
     metered_model(torch.randn(1,3,224,224))
     
     # print(metered_model.structure)
-    print(metered_model.cal)
-    metered_model.profile(metered_model.cal,
+    print(metered_model.mem)
+    metered_model.profile(metered_model.mem,
                           show=True, no_tree=True,
+                          raw_data=False,)
                         #   newcol_name='Percentage',
                         #   newcol_func=lambda col_dict,all_num=metered_model.mem.TotalCost.val: f'{col_dict["Total"]*100/all_num:.3f} %',
                         #   newcol_dependcol=['Total'],
                         #   newcol_type=str,
                         #   newcol_idx=0,
-                          save_to='.',
-                          raw_data=True,
-                          save_format='xlsx')
+                        #   save_to='.',
+                        #   save_format='xlsx')

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -324,13 +324,14 @@ if __name__ == '__main__':
     metered_model(torch.randn(1,3,224,224))
     
     # print(metered_model.structure)
-    print(metered_model.ittp)
-    metered_model.profile(metered_model.ittp,
-                          show=True)
+    print(metered_model.cal)
+    metered_model.profile(metered_model.cal,
+                          show=True, no_tree=True,
                         #   newcol_name='Percentage',
                         #   newcol_func=lambda col_dict,all_num=metered_model.mem.TotalCost.val: f'{col_dict["Total"]*100/all_num:.3f} %',
                         #   newcol_dependcol=['Total'],
                         #   newcol_type=str,
                         #   newcol_idx=0,
-                        #   save_csv='.',
-                        #   save_excel='.')
+                          save_to='.',
+                          raw_data=True,
+                          save_format='xlsx')

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -760,7 +760,7 @@ class TabularRenderer:
             .alias(col_name)
         ).select(final_cols)
 
-    def df2tb(self, df:DataFrame) -> Table:
+    def df2tb(self, df:DataFrame, show_raw:bool = False) -> Table:
         # create rich table
         tb_fields = df.columns
         tb = Table(*tb_fields)
@@ -778,8 +778,15 @@ class TabularRenderer:
         
         # fill table
         for vals_dict in df.iter_rows(named=True):
-            str_vals = [(str(col_val) if col_val is not None else col_none_str[col_name]) 
-                        for col_name,col_val in vals_dict.items()]
+            str_vals = []
+            for col_name,col_val in vals_dict.items():
+                if col_val is None:
+                    str_vals.append(col_none_str[col_name])
+                elif show_raw:
+                    str_vals.append(str(getattr(col_val, 'raw_data', col_val)))
+                else:
+                    str_vals.append(str(col_val))
+            
             tb.add_row(*str_vals)
         
         return tb
@@ -907,7 +914,7 @@ class TabularRenderer:
 
         self.tb_args = table_settings
         self.col_args = column_settings
-        tb = self.df2tb(df=data)
+        tb = self.df2tb(df=data, show_raw=raw_data)
 
         self.datas[stat_name] = data
 

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -826,7 +826,8 @@ class TabularRenderer:
         obj_cols = {col_name:df[col_name].drop_nulls().first().__class__ 
                     for col_name, col_type in df.schema.items() if col_type == pl_object}
         df = df.with_columns([
-            col(col_name).map_elements(lambda s: getattr(s,'raw_data',s.val) if raw_data else str(s))
+            col(col_name).map_elements(lambda s: getattr(s,'raw_data',s.val) if raw_data else str(s),
+                                       return_dtype=float if raw_data else str)
             for col_name, obj_cls in obj_cols.items()
         ])            
         

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -12,7 +12,7 @@ from torch.cuda import Event as cuda_event
 from torch.cuda import synchronize as cuda_sync
 
 from torchmeter.unit import UNIT_TYPE, auto_unit
-from torchmeter.unit import DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit
+from torchmeter.unit import CountUnit, DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit
 
 OPN_TYPE = TypeVar("OperationNode")
 
@@ -160,8 +160,9 @@ class Statistics(ABC):
 class ParamsMeter(Statistics):
 
     detail_val_container:NamedTuple = namedtuple(typename='Params_INFO', 
-                                                 defaults=(None,)*5,
+                                                 defaults=(None,)*6,
                                                  field_names=['Operation_Id', 
+                                                              'Operation_Name',
                                                               'Operation_Type',
                                                               'Param_Name', 
                                                               'Requires_Grad', 
@@ -170,8 +171,8 @@ class ParamsMeter(Statistics):
     overview_val_container:NamedTuple = namedtuple(typename='Params_INFO', 
                                                    defaults=(None,)*5,
                                                    field_names=['Operation_Id', 
+                                                                'Operation_Name',
                                                                 'Operation_Type',
-                                                                'Operation_Name', 
                                                                 'Total_Params', 
                                                                 'Learnable_Params'])
 
@@ -207,8 +208,8 @@ class ParamsMeter(Statistics):
     def val(self) -> NamedTuple:
         self.measure()
         return self.overview_val_container(Operation_Id=self._opnode.node_id,
-                                           Operation_Type=self._opnode.type,
                                            Operation_Name=self._opnode.name,
+                                           Operation_Type=self._opnode.type,
                                            Total_Params=self.TotalNum,
                                            Learnable_Params=self.RegNum)
 
@@ -218,8 +219,9 @@ class ParamsMeter(Statistics):
         
         if not self._model._parameters:
             self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
                                                             Operation_Type=self._opnode.type,
-                                                            Numeric_Num=0))
+                                                            Numeric_Num=UpperLinkData(val=0, unit_sys=CountUnit)))
         else:
             for param_name, param_val in self._model.named_parameters(): 
                 p_num = param_val.numel()
@@ -230,10 +232,11 @@ class ParamsMeter(Statistics):
                     self.__RegNum += p_num
 
                 self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                                Operation_Name=self._opnode.name,
                                                                 Operation_Type=self._opnode.type,
                                                                 Param_Name=param_name,
                                                                 Requires_Grad=p_reg,
-                                                                Numeric_Num=p_num))
+                                                                Numeric_Num=UpperLinkData(val=p_num, unit_sys=CountUnit)))
                 
                 self.__TotalNum += p_num
         

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -184,8 +184,8 @@ class ParamsMeter(Statistics):
         self.is_measured = True if self._model._modules else False # only measure the leaf nodes
 
         _opparent = opnode.parent
-        self.__RegNum = self.init_linkdata(attr_name='RegNum', init_val=0, opparent=_opparent, unit_sys=DecimalUnit)
-        self.__TotalNum = self.init_linkdata(attr_name='TotalNum', init_val=0, opparent=_opparent, unit_sys=DecimalUnit)
+        self.__RegNum = self.init_linkdata(attr_name='RegNum', init_val=0, opparent=_opparent, unit_sys=CountUnit)
+        self.__TotalNum = self.init_linkdata(attr_name='TotalNum', init_val=0, opparent=_opparent, unit_sys=CountUnit)
 
     @property
     def name(self) -> str:

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -30,6 +30,10 @@ class UpperLinkData:
         self.__unit_sys = unit_sys
         self.none_str = none_str # Use when there is a "None" in the column where this data is located while rendering the table.
     
+    @property
+    def raw_data(self):
+        return float(self.val)
+    
     def __iadd__(self, other):
         self.val += other
         self.__upper_update(other)
@@ -66,6 +70,10 @@ class MetricsData:
             return np.percentile(self.vals, 75) - np.percentile(self.vals, 25)
         else:
             return 0.
+    
+    @property
+    def raw_data(self):
+        return self.metrics
     
     def append(self, new_val:Any):
         self.vals = np.append(self.vals, new_val)

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -3,8 +3,7 @@ from collections import namedtuple
 from abc import ABC, abstractmethod
 from operator import attrgetter, mul
 from functools import reduce, partial
-from enum import Enum, IntEnum, IntFlag, unique
-from typing import Any, Callable, List, NamedTuple, Optional, TypeVar, Tuple, Union
+from typing import Any, Callable, List, NamedTuple, Optional, TypeVar, Tuple
 
 import numpy as np
 import torch.nn as nn
@@ -12,56 +11,24 @@ from torch import no_grad
 from torch.cuda import Event as cuda_event
 from torch.cuda import synchronize as cuda_sync
 
+from torchmeter.unit import UNIT_TYPE, auto_unit
+from torchmeter.unit import DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit
+
 OPN_TYPE = TypeVar("OperationNode")
-
-@unique
-class DecimalUnit(IntEnum):
-    T:int = 1e12
-    G:int = 1e9
-    M:int = 1e6
-    K:int = 1e3
-    B:int = 1e0
-
-@unique
-class BinaryUnit(IntFlag):
-    TiB:int = 2**40
-    GiB:int = 2**30
-    MiB:int = 2**20
-    KiB:int = 2**10
-    B:int   = 2**0
-
-@unique
-class TimeUnit(Enum):
-    h:int  = 60**2
-    min:int = 60**1
-    s:int  = 60**0
-    ms:float = 1e-3
-    us:float = 1e-6
-    ns:float = 1e-9
-
-@unique
-class SpeedUnit(IntEnum):
-    TSamPS:int = 1e12
-    GSamPS:int = 1e9
-    MSamPS:int = 1e6
-    KSamPS:int = 1e3
-    SamPS:int  = 1e0
-
-UNIT_TYPE = Union[DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit]
-
-def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> Union[str, None]:
-    for unit in list(unit_system):
-        if val >= unit.value:
-            return f'{val / unit.value:.2f} {unit.name}'
-    return None
 
 class UpperLinkData:
 
-    __slots__ = ['val', '__parent_data']
+    __slots__ = ['val', 'none_str',
+                 '__parent_data', '__unit_sys']
 
-    def __init__(self, val:int=0, parent_data:Optional["UpperLinkData"]=None):
+    def __init__(self, 
+                 val:int=0, parent_data:Optional["UpperLinkData"]=None,
+                 unit_sys:Optional[UNIT_TYPE]=None,
+                 none_str:str='-'):
         self.val = val
         self.__parent_data = parent_data    
+        self.__unit_sys = unit_sys
+        self.none_str = none_str # Use when there is a "None" in the column where this data is located while rendering the table.
     
     def __iadd__(self, other):
         self.val += other
@@ -73,18 +40,21 @@ class UpperLinkData:
             self.__parent_data += other
     
     def __repr__(self):
-        return str(self.val)
+        if self.__unit_sys is not None:
+            return auto_unit(self.val, self.__unit_sys)
+        else:
+            return str(self.val)
 
 class MetricsData:
 
     __slots__ = ['vals',
                  'reduce_func',
-                 'unit_sys']
+                 '__unit_sys']
 
-    def __init__(self, reduce_func:Optional[Callable]=np.mean, unit_system:Optional[UNIT_TYPE]=DecimalUnit):
+    def __init__(self, reduce_func:Optional[Callable]=np.mean, unit_sys:Optional[UNIT_TYPE]=DecimalUnit):
         self.vals = np.array([])
         self.reduce_func = reduce_func if reduce_func is not None else lambda x:x
-        self.unit_sys = unit_system
+        self.__unit_sys = unit_sys
 
     @property
     def metrics(self):
@@ -104,9 +74,9 @@ class MetricsData:
         self.vals = np.array([])
 
     def __repr__(self):
-        if self.unit_sys is not None:
-            return f"{auto_unit(self.metrics, self.unit_sys)}" + ' ± ' + \
-                   f"{auto_unit(self.iqr, self.unit_sys)}"
+        if self.__unit_sys is not None:
+            return f"{auto_unit(self.metrics, self.__unit_sys)}" + ' ± ' + \
+                   f"{auto_unit(self.iqr, self.__unit_sys)}"
         else:
             return f"{self.metrics} ± {self.iqr}"
 
@@ -153,13 +123,15 @@ class Statistics(ABC):
     def init_linkdata(self,
                       attr_name:str,
                       init_val:int=0,
-                      opparent:Optional["OperationNode"]=None): # noqa # type: ignore
+                      opparent:Optional[OPN_TYPE]=None,
+                      **kwargs) -> UpperLinkData:
         if opparent is None:
-            link_data = UpperLinkData(val=init_val)
+            link_data = UpperLinkData(val=init_val, **kwargs)
         else:
             upper_getter = attrgetter(f'{self.name}.{attr_name}')
             link_data = UpperLinkData(val=init_val, 
-                                      parent_data=upper_getter(opparent))
+                                      parent_data=upper_getter(opparent),
+                                      **kwargs)
         return link_data
 
     def __repr__(self):
@@ -170,9 +142,8 @@ class Statistics(ABC):
         for field in self.ov_fields:
             field_val = getattr(self.val, field, 'N/A')
             if isinstance(field_val, UpperLinkData):
-                field_val = float(field_val.val) # get the value
-                unit_system = BinaryUnit if repr_str.startswith('Memory') else DecimalUnit
-                repr_str += '• ' + f"{field.rjust(max_len)} = {field_val} = {auto_unit(field_val, unit_system)}\n"
+                numeric_val = float(field_val.val) # get the value
+                repr_str += '• ' + f"{field.rjust(max_len)} = {numeric_val} = {field_val}\n"
             else:
                 repr_str += '• ' + f"{field.rjust(max_len)} = {field_val}\n"
 
@@ -204,8 +175,8 @@ class ParamsMeter(Statistics):
         self.is_measured = True if self._model._modules else False # only measure the leaf nodes
 
         _opparent = opnode.parent
-        self.__RegNum = self.init_linkdata(attr_name='RegNum', init_val=0, opparent=_opparent)
-        self.__TotalNum = self.init_linkdata(attr_name='TotalNum', init_val=0, opparent=_opparent)
+        self.__RegNum = self.init_linkdata(attr_name='RegNum', init_val=0, opparent=_opparent, unit_sys=DecimalUnit)
+        self.__TotalNum = self.init_linkdata(attr_name='TotalNum', init_val=0, opparent=_opparent, unit_sys=DecimalUnit)
 
     @property
     def name(self) -> str:
@@ -234,7 +205,7 @@ class ParamsMeter(Statistics):
                                            Learnable_Params=self.RegNum)
 
     def measure(self) -> None:
-        if self.is_measured:
+        if self.is_measured: # TODO: non-leaf layer may have its own parameter
             return
         
         if not self._model._parameters:
@@ -290,8 +261,10 @@ class CalMeter(Statistics):
         self.is_measured = True if self._model._modules else False # only measure the leaf nodes
 
         _opparent = opnode.parent
-        self.__Macs = self.init_linkdata(attr_name='Macs', init_val=0, opparent=_opparent)
-        self.__Flops = self.init_linkdata(attr_name='Flops', init_val=0, opparent=_opparent)
+        self.__Macs = self.init_linkdata(attr_name='Macs', init_val=0, opparent=_opparent, 
+                                         unit_sys=DecimalUnit, none_str='Not Supported')
+        self.__Flops = self.init_linkdata(attr_name='Flops', init_val=0, opparent=_opparent, 
+                                          unit_sys=DecimalUnit, none_str='Not Supported')
 
     @property
     def name(self) -> str:
@@ -368,8 +341,8 @@ class CalMeter(Statistics):
                                                         Bias=bool(is_bias),
                                                         Input_Shape=list(input[0].shape),
                                                         Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs.val,
-                                                        FLOPs=self.Flops.val)
+                                                        MACs=self.Macs,
+                                                        FLOPs=self.Flops)
         )
     
     def __linear_hook(self, module, input, output):
@@ -389,8 +362,8 @@ class CalMeter(Statistics):
                                                         Bias=bool(is_bias),
                                                         Input_Shape=list(input[0].shape),
                                                         Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs.val,
-                                                        FLOPs=self.Flops.val)
+                                                        MACs=self.Macs,
+                                                        FLOPs=self.Flops)
         )
 
     def __BN_hook(self, module, input, output):
@@ -404,8 +377,8 @@ class CalMeter(Statistics):
                                                         Operation_Type=self._opnode.type,
                                                         Input_Shape=list(input[0].shape),
                                                         Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs.val,
-                                                        FLOPs=self.Flops.val)
+                                                        MACs=self.Macs,
+                                                        FLOPs=self.Flops)
         )
 
     def __activate_hook(self, module, input, output):
@@ -434,8 +407,8 @@ class CalMeter(Statistics):
                                                         Operation_Type=self._opnode.type,
                                                         Input_Shape=list(input[0].shape),
                                                         Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs.val,
-                                                        FLOPs=self.Flops.val)
+                                                        MACs=self.Macs,
+                                                        FLOPs=self.Flops)
         )
 
     def __pool_hook(self, module, input, output):
@@ -459,8 +432,8 @@ class CalMeter(Statistics):
                                                         Kernel_Size=list(k) if len(k)>1 else [k[0]]*2,
                                                         Input_Shape=list(input[0].shape),
                                                         Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs.val,
-                                                        FLOPs=self.Flops.val)
+                                                        MACs=self.Macs,
+                                                        FLOPs=self.Flops)
         )
 
     def __not_support_hook(self, module, input, output):
@@ -501,10 +474,10 @@ class MemMeter(Statistics):
         self.is_measured = True if self._model._modules else False # only measure the leaf nodes
 
         _opparent = opnode.parent
-        self.__ParamCost = self.init_linkdata(attr_name='ParamCost', init_val=0, opparent=_opparent)
-        self.__BufferCost = self.init_linkdata(attr_name='BufferCost', init_val=0, opparent=_opparent)
-        self.__FeatureMapCost = self.init_linkdata(attr_name='FeatureMapCost', init_val=0, opparent=_opparent)
-        self.__TotalCost = self.init_linkdata(attr_name='TotalCost', init_val=0, opparent=_opparent)
+        self.__ParamCost = self.init_linkdata(attr_name='ParamCost', init_val=0, opparent=_opparent, unit_sys=BinaryUnit)
+        self.__BufferCost = self.init_linkdata(attr_name='BufferCost', init_val=0, opparent=_opparent, unit_sys=BinaryUnit)
+        self.__FeatureMapCost = self.init_linkdata(attr_name='FeatureMapCost', init_val=0, opparent=_opparent, unit_sys=BinaryUnit)
+        self.__TotalCost = self.init_linkdata(attr_name='TotalCost', init_val=0, opparent=_opparent, unit_sys=BinaryUnit)
 
     @property
     def name(self) -> str:
@@ -537,10 +510,10 @@ class MemMeter(Statistics):
         return self.overview_val_container(Operation_Id=self._opnode.node_id,
                                            Operation_Type=self._opnode.type,
                                            Operation_Name=self._opnode.name,
-                                           Param_Cost=self.__ParamCost,
-                                           Buffer_Cost=self.__BufferCost,
-                                           FeatureMap_Cost=self.__FeatureMapCost,
-                                           Total=self.__TotalCost)
+                                           Param_Cost=self.ParamCost,
+                                           Buffer_Cost=self.BufferCost,
+                                           FeatureMap_Cost=self.FeatureMapCost,
+                                           Total=self.TotalCost)
 
     def measure(self):
         if self.is_measured:
@@ -572,11 +545,10 @@ class MemMeter(Statistics):
         self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
                                                         Operation_Name=self._opnode.name,
                                                         Operation_Type=self._opnode.type,
-                                                        Param_Cost=auto_unit(param_cost,unit_system=BinaryUnit), 
-                                                        Buffer_Cost=auto_unit(buffer_cost,unit_system=BinaryUnit), 
-                                                        FeatureMap_Cost=auto_unit(feat_cost,unit_system=BinaryUnit), 
-                                                        Total=auto_unit(param_cost + buffer_cost + feat_cost,
-                                                                        unit_system=BinaryUnit)))
+                                                        Param_Cost=self.ParamCost if param_cost else None, 
+                                                        Buffer_Cost=self.BufferCost if buffer_cost else None, 
+                                                        FeatureMap_Cost=self.FeatureMapCost, 
+                                                        Total=self.TotalCost))
 
 class ITTPMeter(Statistics):
 
@@ -602,8 +574,8 @@ class ITTPMeter(Statistics):
         
         self.__stat_ls = [] # record the inference time and throughput of each operation
 
-        self.__InferTime = MetricsData(reduce_func=np.median, unit_system=TimeUnit)
-        self.__Throughput = MetricsData(reduce_func=np.median, unit_system=SpeedUnit)
+        self.__InferTime = MetricsData(reduce_func=np.median, unit_sys=TimeUnit)
+        self.__Throughput = MetricsData(reduce_func=np.median, unit_sys=SpeedUnit)
 
     @property
     def name(self) -> str:
@@ -673,7 +645,7 @@ class ITTPMeter(Statistics):
         self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
                                                         Operation_Name=self._opnode.name,
                                                         Operation_Type=self._opnode.type,
-                                                        Infer_Time=str(self.__InferTime),
-                                                        Throughput=str(self.__Throughput)))
+                                                        Infer_Time=str(self.InferTime),
+                                                        Throughput=str(self.Throughput)))
 
 

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -653,7 +653,7 @@ class ITTPMeter(Statistics):
         self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
                                                         Operation_Name=self._opnode.name,
                                                         Operation_Type=self._opnode.type,
-                                                        Infer_Time=str(self.InferTime),
-                                                        Throughput=str(self.Throughput)))
+                                                        Infer_Time=self.InferTime,
+                                                        Throughput=self.Throughput))
 
 

--- a/torchmeter/unit.py
+++ b/torchmeter/unit.py
@@ -40,4 +40,4 @@ def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> Union[str, None
     for unit in list(unit_system):
         if val >= unit.value:
             return f'{val / unit.value:.2f} {unit.name}'
-    return None
+    return str(val)

--- a/torchmeter/unit.py
+++ b/torchmeter/unit.py
@@ -10,6 +10,13 @@ class DecimalUnit(IntEnum):
     B:int = 1e0
 
 @unique
+class CountUnit(IntEnum):
+    T:int = 1e12
+    G:int = 1e9
+    M:int = 1e6
+    K:int = 1e3
+
+@unique
 class BinaryUnit(IntFlag):
     TiB:int = 2**40
     GiB:int = 2**30
@@ -39,5 +46,8 @@ UNIT_TYPE = Union[DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit]
 def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> Union[str, None]:
     for unit in list(unit_system):
         if val >= unit.value:
-            return f'{val / unit.value:.2f} {unit.name}'
+            if val % unit.value:
+                return f'{val / unit.value:.2f} {unit.name}'
+            else:
+                return f'{val // unit.value} {unit.name}'
     return str(val)

--- a/torchmeter/unit.py
+++ b/torchmeter/unit.py
@@ -1,0 +1,43 @@
+from typing import Union
+from enum import Enum, IntEnum, IntFlag, unique
+
+@unique
+class DecimalUnit(IntEnum):
+    T:int = 1e12
+    G:int = 1e9
+    M:int = 1e6
+    K:int = 1e3
+    B:int = 1e0
+
+@unique
+class BinaryUnit(IntFlag):
+    TiB:int = 2**40
+    GiB:int = 2**30
+    MiB:int = 2**20
+    KiB:int = 2**10
+    B:int   = 2**0
+
+@unique
+class TimeUnit(Enum):
+    h:int  = 60**2
+    min:int = 60**1
+    s:int  = 60**0
+    ms:float = 1e-3
+    us:float = 1e-6
+    ns:float = 1e-9
+
+@unique
+class SpeedUnit(IntEnum):
+    TSamPS:int = 1e12
+    GSamPS:int = 1e9
+    MSamPS:int = 1e6
+    KSamPS:int = 1e3
+    SamPS:int  = 1e0
+
+UNIT_TYPE = Union[DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit]
+
+def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> Union[str, None]:
+    for unit in list(unit_system):
+        if val >= unit.value:
+            return f'{val / unit.value:.2f} {unit.name}'
+    return None


### PR DESCRIPTION
## 📋 Summary

> [!IMPORTANT]
> - [ ] This PR fixes an issue. [Link]() <!--Link to related issues if applicable -->    
> - [x] This PR adds something new.
> - [ ] This PR is **not** a code change (e.g. `README`, typos, ...)
> - [ ] This PR has been tested.

<!-- What is this pull request for? Does it fix any issues? -->

## 📝 Changes

<!-- Describe what you change and what the purpose in this pull request. -->

<details>
<summary>Details</summary>

- `torchmeter/display.py`: add `raw_data` option when rendering and saving report table. Additionally, abstract `save_csv` and `save_excel` as `self.export()`.
- `torchmeter/statistic.py`: add `raw_data` and `none_str` property to `UpperLinkData` and `MetricsData`, in order to use their instance as backend and the specific value as frontend.
- `torchmeter/unit.py`: separate the logic of unit for clear code structure.

</details>