### PR TITLE
Chore/prerelease chore

### DIFF
--- a/default_cfg.yaml
+++ b/default_cfg.yaml
@@ -1,0 +1,94 @@
+# time interval in outputing rendered object(include tree and table)
+render_interval: 0.15         # unit: second
+
+# Whether to fold the repeat part in rendering model structure tree
+tree_fold_repeat: True 
+
+# Display settings for repeat blocks in the model structure tree
+# It actually is a rich.panel.Panel object, refer to https://rich.readthedocs.io/en/latest/panel.html 
+tree_repeat_block_args:
+  title: '[i]Repeat [[b]<repeat_time>[/b]] Times[/]' # Title of the repeat block, accept rich styling
+  title_align: center         # Title alignment, left, center, right
+  subtitle: null              # Subtitle of the repeat block, accept rich styling
+  subtitle_align: center      # Subtitle alignment, left, center, right
+  style: dark_goldenrod   # Style of the repeat block, execute `python -m rich.theme` to get more
+  highlight: true             # Whether to highlight the value (number, string...)
+  box: HEAVY_EDGE             # Box type, use its name directly like here!!! execute `python -m rich.box` to get more
+  border_style: dim           # Border style, execute `python -m rich.theme` to get more
+  width: null                 # Width of the repeat block, null means auto
+  height: null                # Height of the repeat block, null means auto
+  padding:                    # Padding of the repeat block
+    - 0                       # top/bottom padding
+    - 1                       # left/right padding
+  expand: false               # Whether to expand the repeat block to full screen size
+
+
+# Fine-grained display settings for each level in the model structure tree
+# It actually is a rich.tree.Tree object, refer to https://rich.readthedocs.io/en/latest/tree.html
+# the `level` field is necessary!!!! It indicates that the following settings will be applied to that layer.
+# level 0 indicates the root node(i.e. the model itself), level 1 indicates the first layer of model children, and so on.
+tree_levels_args:
+  default:   # Necessary!!!! Alternatively, you can set use 'all' to apply below settings to all levels
+    label: '[b gray35](<node_id>) [green]<name>[/green] [cyan]<type>[/]' # node represent string, accept rich styling
+    style: tree               # Style of the node, execute `python -m rich.theme` to get more
+    guide_style: light_coral  # Guide style of the node, execute `python -m rich.theme` to get more
+    highlight: true           # Whether to highlight the value (number, string...)
+    hide_root: false          # Whether to not display the node in this level 
+    expanded: true            # Whether to display the node's children
+
+  '0':   # Necessary!!!! The number indicates that the following settings will be applied to that layer.   
+    label: '[b light_coral]<name>[/]'
+    guide_style: light_coral
+    # if other settings is not specified, it will use the default settings defined by the `level default`
+
+
+# Display settings for each column in the profile table
+# It actually is a rich.table.Column object, refer to https://rich.readthedocs.io/en/latest/columns.html
+table_column_args:
+  style: none       # Style of the column, execute `python -m rich.theme` to get more
+  justify: center   # Justify of the column, left, center, right
+  vertical: middle  # Vertical align of the column, top, middle, bottom
+  overflow: fold    # Overflow of the column, fold, crop, ellipsis, see https://rich.readthedocs.io/en/latest/console.html?highlight=overflow#overflow
+  no_warp: false    # Prevent wrapping of text within the column.
+
+
+# Display settings for the profile table
+# It actually is a rich.table.Table object, refer to https://rich.readthedocs.io/en/latest/tables.html
+table_display_args:
+  style: spring_green4        # Style of the table, execute `python -m rich.theme` to get more
+  highlight: true             # Whether to highlight the value (number, string...)
+
+  width: null                 # The width in characters of the table, or `null` to automatically fit
+  min_width: null             # The minimum width of the table, or `null` for no minimum
+  expand: false               # Whether to expand the table to full screen size
+  padding:                    # Padding for cells 
+    - 0                       # top/bottom padding
+    - 1                       # left/right padding
+  collapse_padding: false     # Whether to enable collapsing of padding around cells
+  pad_edge: true              # Whether to enable padding of edge cells
+  leading: 0                  # Number of blank lines between rows (precludes `show_lines` below)
+
+  title: null                 # Title of the table, accept rich styling
+  title_style: bold           # Style of the title, execute `python -m rich.theme` to get more
+  title_justify: center       # Justify of the title, left, center, right
+  caption: null               # The table caption rendered below, accept rich styling
+  caption_style: null         # Style of the caption, execute `python -m rich.theme` to get more
+  caption_justify: center     # Justify of the caption, left, center, right
+
+  show_header: true           # Whether to show the header row
+  header_style: bold          # Style of the header, execute `python -m rich.theme` to get more
+
+  show_footer: false          # Whether to show the footer row
+  footer_style: italic        # Style of the footer, execute `python -m rich.theme` to get more
+
+  show_lines: false           # Whether to show lines between rows
+  row_styles: null            # Optional list of row styles, if more than one style is given then the styles will alternate
+
+  show_edge: true             # Whether to show the edge of the table
+  box: ROUNDED                # Box type, use its name directly like here!!! execute `python -m rich.box` to get more
+  safe_box: true              # Whether to disable box characters that don't display on windows legacy terminal with *raster* fonts
+  border_style: null          # Style of the border, execute `python -m rich.theme` to get more
+
+# Display settings about how to combine the tree and table in the profile
+combine:
+  horizon_gap: 2  # horizontal gap in pixel between the tree and table

--- a/default_cfg.yaml
+++ b/default_cfg.yaml
@@ -11,10 +11,12 @@ tree_repeat_block_args:
   title_align: center         # Title alignment, left, center, right
   subtitle: null              # Subtitle of the repeat block, accept rich styling
   subtitle_align: center      # Subtitle alignment, left, center, right
+  
   style: dark_goldenrod   # Style of the repeat block, execute `python -m rich.theme` to get more
   highlight: true             # Whether to highlight the value (number, string...)
   box: HEAVY_EDGE             # Box type, use its name directly like here!!! execute `python -m rich.box` to get more
   border_style: dim           # Border style, execute `python -m rich.theme` to get more
+  
   width: null                 # Width of the repeat block, null means auto
   height: null                # Height of the repeat block, null means auto
   padding:                    # Padding of the repeat block

--- a/torchmeter/config.py
+++ b/torchmeter/config.py
@@ -1,0 +1,313 @@
+import os
+import warnings
+from threading import Lock
+from typing import Optional
+from enum import Enum, unique
+from types import SimpleNamespace
+
+import yaml
+from rich import box
+
+from torchmeter.utils import indent_str
+
+DEFAULT_FIELDS = ['render_interval',
+                  'tree_fold_repeat', 'tree_repeat_block_args', 'tree_levels_args', 
+                  'table_column_args','table_display_args', 
+                  'combine']
+DEFAULT_CFG = """\
+render_interval: 0.15
+
+tree_fold_repeat: True
+
+tree_repeat_block_args:
+    title: '[i]Repeat [[b]<repeat_time>[/b]] Times[/]'
+    title_align: center
+    subtitle: null
+    subtitle_align: center
+    
+    style: dark_goldenrod
+    highlight: True
+    
+    box: HEAVY_EDGE
+    border_style: dim
+    
+    width: null
+    height: null
+    padding: 
+        - 0
+        - 1
+    expand: False
+        
+tree_levels_args:
+    default:
+        label: '[b gray35](<node_id>) [green]<name>[/green] [cyan]<type>[/]'
+        
+        style: tree
+        guide_style: light_coral
+        highlight: True
+        
+        hide_root: False
+        expanded: True
+      
+    '0': 
+        label: '[b light_coral]<name>[/]'
+        guide_style: light_coral
+          
+table_column_args:
+    style: none
+    
+    justify: center
+    vertical: middle
+    
+    overflow: fold
+    no_warp: False
+        
+table_display_args:
+    style: spring_green4
+    highlight: True
+    
+    width: null
+    min_width: null
+    expand: False
+    padding: 
+        - 0
+        - 1
+    collapse_padding: False
+    pad_edge: True
+    leading: 0
+    
+    title: null
+    title_style: bold
+    title_justify: center
+    
+    caption: null
+    caption_style: null
+    caption_justify: center
+    
+    show_header: True
+    header_style: bold
+    
+    show_footer: False
+    footer_style: italic
+    
+    show_lines: False
+    row_styles: null
+    
+    show_edge: True
+    box: ROUNDED
+    safe_box: True
+    border_style: null
+
+combine:
+    horizon_gap: 2
+"""
+
+@unique
+class BOX(Enum):
+    ASCII = box.ASCII
+    ASCII2 = box.ASCII2
+    ASCII_DOUBLE_HEAD = box.ASCII_DOUBLE_HEAD
+    DOUBLE = box.DOUBLE
+    DOUBLE_EDGE = box.DOUBLE_EDGE
+    HEAVY = box.HEAVY
+    HEAVY_EDGE = box.HEAVY_EDGE
+    HEAVY_HEAD = box.HEAVY_HEAD
+    HORIZONTALS = box.HORIZONTALS
+    MARKDOWN = box.MARKDOWN
+    MINIMAL = box.MINIMAL
+    MINIMAL_DOUBLE_HEAD = box.MINIMAL_DOUBLE_HEAD
+    MINIMAL_HEAVY_HEAD = box.MINIMAL_HEAVY_HEAD
+    ROUNDED = box.ROUNDED
+    SIMPLE = box.SIMPLE
+    SIMPLE_HEAD = box.SIMPLE_HEAD
+    SIMPLE_HEAVY = box.SIMPLE_HEAVY
+    SQUARE = box.SQUARE
+    SQUARE_DOUBLE_HEAD = box.SQUARE_DOUBLE_HEAD
+
+UNSAFE_KV = {
+    'box': BOX
+}
+
+
+def dict_to_namespace(d):
+    """
+    Recursively converts a dictionary to a SimpleNamespace object.
+    """
+    assert isinstance(d, dict), f"Input must be a dictionary, but got {type(d)}"
+    
+    ns = SimpleNamespace()
+    for k, v in d.items():
+        # overwrite the value of unsafe key to get the unrepresent value
+        if k in UNSAFE_KV:
+            v = getattr(UNSAFE_KV[k], v).value
+
+        if isinstance(v, dict):
+            setattr(ns, k, dict_to_namespace(v))
+            
+        elif isinstance(v, list):
+            _list = []
+            for item in v:
+                if isinstance(item, dict):
+                    _list.append(dict_to_namespace(item))
+                else:
+                    _list.append(item)
+            setattr(ns, k, _list)
+            
+        else:
+            setattr(ns, k, v)
+            
+    return ns
+
+def namespace_to_dict(ns, safe_resolve=False):
+    """
+    Recursively converts a SimpleNamespace object to a dictionary.
+    """
+    assert isinstance(ns, SimpleNamespace), f"Input must be a SimpleNamespace, but got {type(ns)}"
+
+    d = {}
+    for k, v in ns.__dict__.items():
+        # transform the unrepresent value to its name defined in corresponding Enum
+        if k in UNSAFE_KV and safe_resolve:
+            v = UNSAFE_KV[k](v).name
+
+        if isinstance(v, SimpleNamespace):
+            d[k] = namespace_to_dict(v, safe_resolve=safe_resolve)
+            
+        elif isinstance(v, list):
+            _list = []
+            for item in v:
+                if isinstance(item, SimpleNamespace):
+                    _list.append(namespace_to_dict(item, safe_resolve=safe_resolve))
+                else:
+                    _list.append(item)
+            d[k] = _list
+            
+        else:
+            d[k] = v
+            
+    return d
+
+def get_config():
+    cfg_file = os.environ.get('TORCHMETER_CONFIG', None)
+    return Config(config_file=cfg_file)
+
+class ConfigMeta(type):
+    """To achieve sigleton pattern"""
+    
+    _instances = None
+    _thread_lock = Lock()
+
+    def __call__(cls, *args, **kwargs):
+        with cls._thread_lock:
+            if cls._instances is None:
+                instance = super().__call__(*args, **kwargs)
+                cls._instances = instance
+        return cls._instances
+
+class Config(metaclass=ConfigMeta):
+    
+    """You can only read or write the predefined fields in the instance"""
+    
+    __slots__ = DEFAULT_FIELDS + ['__cfg_file']
+    
+    def __init__(self, config_file:Optional[str]=None):
+        self.__cfg_file = None
+        
+        self.config_file = config_file
+    
+    @property
+    def config_file(self):
+        return self.__cfg_file
+    
+    @config_file.setter
+    def config_file(self, config_file:Optional[str]=None):
+        assert config_file is None or isinstance(config_file, str), \
+                f"You must pass in a string or None to change config or use the default config, \
+                  but got {type(config_file)}."
+                
+        if config_file:
+            config_file = os.path.abspath(config_file)
+            assert os.path.exists(config_file), f"Config file {config_file} does not exist."
+        
+        self.__cfg_file = config_file
+        self.__load()
+        self.check_integrity()
+            
+    def __load(self):
+        if self.config_file is None:
+            raw_data = yaml.safe_load(DEFAULT_CFG)
+        else:
+            with open(self.config_file, 'r') as f:
+                raw_data = yaml.safe_load(f)
+        
+        ns:SimpleNamespace = dict_to_namespace(raw_data)
+        for field in ns.__dict__.keys():
+            setattr(self, field, getattr(ns, field))          
+
+    def restore(self):
+        self.__load()
+        self.check_integrity()
+
+    def check_integrity(self):
+        default_cfg = yaml.safe_load(DEFAULT_CFG)
+        for field in DEFAULT_FIELDS:
+            if not hasattr(self, field):
+                warnings.warn(message=f"Config file {self.config_file} does not contain '{field}' key, \
+                                        using default config instead.")
+                ns = dict_to_namespace({field:default_cfg[field]})
+                setattr(self, field, getattr(ns, field))
+    
+    def asdict(self, safe_resolve=False):
+        d = {}
+        for field in DEFAULT_FIELDS:
+            field_val = getattr(self, field)
+            if isinstance(field_val, SimpleNamespace):
+                d[field] = namespace_to_dict(field_val, safe_resolve=safe_resolve)
+            elif isinstance(field_val, list):
+                d[field] = [namespace_to_dict(v, safe_resolve=safe_resolve) if isinstance(v, SimpleNamespace) else v 
+                            for v in field_val]
+            elif isinstance(field_val, dict):
+                d[field] = {k:namespace_to_dict(v, safe_resolve=safe_resolve) if isinstance(v, SimpleNamespace) else v 
+                            for k,v in field_val.items()}
+            else:
+                d[field] = field_val
+        return d
+    
+    def dump(self, save_path:str):
+        d = self.asdict(safe_resolve=True)
+
+        with open(save_path, 'w') as f:
+            yaml.safe_dump(d, f, 
+                           indent=2, sort_keys=False,
+                           encoding='utf-8', allow_unicode=True)        
+    
+    def __repr__(self):
+        d = self.asdict(safe_resolve=True)
+
+        s = '• Config file: ' + (self.config_file if self.config_file else 'None(default setting below)') + '\n'
+        for field_name, field_vals in d.items():
+            not_container = False
+            field_vals_repr = [f'\n• {field_name}: ']
+            
+            if isinstance(field_vals, dict):
+                field_vals_repr.extend([f'{k} = {v} ' for k,v in field_vals.items()])
+            elif isinstance(field_vals, list):
+                field_vals_repr.extend([f'- {v}' for v in field_vals])
+            else:
+                not_container = True
+                field_vals_repr.append(f'{field_vals}')
+            
+            # concat field name and field value if it is not a container
+            if len(field_vals_repr) == 2 and not_container:
+                field_vals_repr = [''.join(field_vals_repr)]
+                
+            s += indent_str(field_vals_repr, indent=4, process_first=False) + '\n'
+        return s
+
+if __name__ == '__main__':
+    default_cfg = Config()
+    print(default_cfg)
+    cfg1 = Config()
+    cfg2 = Config()
+    if id(cfg1) == id(cfg2):
+        print('Singleton Pattern Success.')

--- a/torchmeter/config.py
+++ b/torchmeter/config.py
@@ -10,6 +10,8 @@ from rich import box
 
 from torchmeter.utils import indent_str
 
+__all__ = ["get_config", "Config"]
+
 DEFAULT_FIELDS = ['render_interval',
                   'tree_fold_repeat', 'tree_repeat_block_args', 'tree_levels_args', 
                   'table_column_args','table_display_args', 
@@ -133,7 +135,8 @@ def dict_to_namespace(d):
     """
     Recursively converts a dictionary to a FlagNameSpace object.
     """
-    assert isinstance(d, dict), f"Input must be a dictionary, but got {type(d)}"
+    if not isinstance(d, dict):
+        raise TypeError(f"Input must be a dictionary, but got {type(d)}")
     
     ns = FlagNameSpace()
     for k, v in d.items():
@@ -165,7 +168,8 @@ def namespace_to_dict(ns, safe_resolve=False):
     """
     Recursively converts a FlagNameSpace object to a dictionary.
     """
-    assert isinstance(ns, SimpleNamespace), f"Input must be an instance of SimpleNamespace, but got {type(ns)}"
+    if not isinstance(ns, SimpleNamespace):
+        raise TypeError(f"Input must be an instance of SimpleNamespace, but got {type(ns)}")
 
     d = {}
     for k, v in ns.__dict__.items():
@@ -209,12 +213,14 @@ class FlagNameSpace(SimpleNamespace):
         self.mark_unchange()
             
     def __setattr__(self, key, value):
-        assert key != self.__flag_key, f"`{key}` is preserved for internal use, could never be changed."
+        if key == self.__flag_key:
+            raise AttributeError(f"`{key}` is preserved for internal use, could never be changed.")
         super().__setattr__(key, value)
         self.mark_change()
     
     def __delattr__(self, key):
-        assert key != self.__flag_key, f"`{key}` is preserved for internal use, can not be deleted."
+        if key == self.__flag_key:
+            raise AttributeError(f"`{key}` is preserved for internal use, could never be deleted.")
         super().__delattr__(key)
         self.mark_change()
     
@@ -263,13 +269,16 @@ class Config(metaclass=ConfigMeta):
     
     @config_file.setter
     def config_file(self, config_file:Optional[str]=None):
-        assert config_file is None or isinstance(config_file, str), \
-                f"You must pass in a string or None to change config or use the default config, \
-                  but got {type(config_file)}."
+        if config_file is not None and not isinstance(config_file, str):
+            raise TypeError("You must pass in a string or None to change config or use the default config, " + \
+                            f"but got {type(config_file)}.")
                 
         if config_file:
             config_file = os.path.abspath(config_file)
-            assert os.path.exists(config_file), f"Config file {config_file} does not exist."
+            if not os.path.isfile(config_file):
+                raise FileNotFoundError(f"Config file {config_file} does not exist.")
+            if not config_file.endswith('.yaml'):
+                raise ValueError(f"Config file must be a yaml file, but got {config_file}")
         
         self.__cfg_file = config_file
         self.__load()

--- a/torchmeter/config.py
+++ b/torchmeter/config.py
@@ -287,15 +287,15 @@ class Config(metaclass=ConfigMeta):
         s = '• Config file: ' + (self.config_file if self.config_file else 'None(default setting below)') + '\n'
         for field_name, field_vals in d.items():
             not_container = False
-            field_vals_repr = [f'\n• {field_name}: ']
+            field_vals_repr = [f"\n• {field_name}: "]
             
             if isinstance(field_vals, dict):
-                field_vals_repr.extend([f'{k} = {v} ' for k,v in field_vals.items()])
+                field_vals_repr.extend([f"{k} = {v} " for k,v in field_vals.items()])
             elif isinstance(field_vals, list):
-                field_vals_repr.extend([f'- {v}' for v in field_vals])
+                field_vals_repr.extend([f"- {v}" for v in field_vals])
             else:
                 not_container = True
-                field_vals_repr.append(f'{field_vals}')
+                field_vals_repr.append(str(field_vals))
             
             # concat field name and field value if it is not a container
             if len(field_vals_repr) == 2 and not_container:

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -1,8 +1,7 @@
 from inspect import signature
 from functools import partial
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple
 
-import torch
 import torch.nn as nn
 from tqdm import tqdm
 from rich import get_console
@@ -11,6 +10,8 @@ from rich.panel import Panel
 from rich.layout import Layout
 from rich.columns import Columns
 from rich.box import HORIZONTALS
+from torch import Tensor
+from torch import device as tc_device
 
 from torchmeter.config import get_config
 from torchmeter.engine import OperationTree
@@ -19,15 +20,18 @@ from torchmeter.display import TreeRenderer, TabularRenderer, render_perline
 
 __cfg__ = get_config()
 
+__all__ = ["Meter"]
+
 class Meter:
 
     def __init__(self, 
                  model: nn.Module,
-                 device:str='cpu'):
+                 device:str='cpu') -> None:
         
-        self.__device = torch.device(device)
+        self.__device = tc_device(device)
 
-        assert isinstance(model, nn.Module), f"model must be an instance of torch.nn.Module, but got {type(model)}"
+        if not isinstance(model, nn.Module):
+            raise TypeError(f"model must be a nn.Module, but got {type(model)}.")
         self.model = model.to(self.__device)
 
         self.ipt = {'args':tuple(), 'kwargs':dict()} # TODO: self.ipt_infer()
@@ -43,28 +47,28 @@ class Meter:
         self.ittp_warmup = 50
         self.ittp_benchmark_time = 100
 
-    def __call__(self, *args, **kwargs):
-        self.ipt = {'args': tuple(x.to(self.device) for x in args if isinstance(x, torch.Tensor)), 
-                    'kwargs': {k:v.to(self.device) for k,v in kwargs.items() if isinstance(v, torch.Tensor)}}
+    def __call__(self, *args, **kwargs) -> Any:
+        self.ipt = {'args': args, 'kwargs': kwargs}
+        self._ipt2device()
         return self.model(*self.ipt['args'], **self.ipt['kwargs'])
     
     @property
-    def device(self):
+    def device(self) -> tc_device:
         return self.__device
     
     @device.setter
-    def device(self, new_device:str):
-        self.__device = torch.device(new_device)
+    def device(self, new_device:str) -> None:
+        self.__device = tc_device(new_device)
         self.model.to(self.__device)
-        self.ipt = {'args': tuple(x.to(self.device) for x in self.ipt['args'] if isinstance(x, torch.Tensor)), 
-                    'kwargs': {k:v.to(self.device) for k,v in self.ipt['kwargs'].items() if isinstance(v, torch.Tensor)}}
+        if not self._is_ipt_empty():
+            self._ipt2device()
 
     @property
     def tree_levels_args(self):
         return self.tree_renderer.tree_levels_args
     
     @tree_levels_args.setter
-    def tree_levels_args(self, custom_args:Union[List[Dict[str, Any]], Dict[Any, Dict[str, Any]]]) -> None:
+    def tree_levels_args(self, custom_args:Dict[Any, Dict[str, Any]]) -> None:
         self.tree_renderer.tree_levels_args = custom_args
 
     @property
@@ -118,10 +122,7 @@ class Meter:
     @property
     def param(self):
         if not self.__measure_param:
-            for node in self.optree.all_nodes:
-                if node.is_leaf:
-                    node.param.measure()
-
+            list(map(lambda node: node.param.measure(), self.optree.all_nodes))
             self.__measure_param = True
 
         return self.optree.root.param
@@ -129,16 +130,17 @@ class Meter:
     @property
     def cal(self):
         if not self.__measure_cal:
-            if len(self.ipt['args']) + len(self.ipt['kwargs']) == 0:
-                raise ValueError("Input unknown! You should perform at least one feed-forward inference before measuring calculation!") 
+            if self._is_ipt_empty():
+                raise RuntimeError("Input unknown! You should perform at least one feed-forward inference before measuring calculation!") 
 
-            hook_ls = [node.cal.measure() for node in self.optree.all_nodes if node.is_leaf]
+            hook_ls = [node.cal.measure() for node in self.optree.all_nodes]
 
             # feed forwad
+            self._ipt2device()
             self.model(*self.ipt['args'], **self.ipt['kwargs']) 
 
             # remove hooks after measurement
-            list(map(lambda x:x.remove(), hook_ls)) 
+            list(map(lambda x:x.remove() if x is not None else None, hook_ls)) 
 
             self.__measure_cal = True
         
@@ -147,16 +149,17 @@ class Meter:
     @property
     def mem(self):
         if not self.__measure_mem:
-            if len(self.ipt['args']) + len(self.ipt['kwargs']) == 0:
-                raise ValueError("Input unknown! You should perform at least one feed-forward inference before measuring the memory cost!") 
+            if self._is_ipt_empty():
+                raise RuntimeError("Input unknown! You should perform at least one feed-forward inference before measuring the memory cost!") 
 
-            hook_ls = [node.mem.measure() for node in self.optree.all_nodes if node.is_leaf]
+            hook_ls = [node.mem.measure() for node in self.optree.all_nodes]
 
             # feed forwad
+            self._ipt2device()
             self.model(*self.ipt['args'], **self.ipt['kwargs']) 
 
             # remove hooks after measurement
-            list(map(lambda x:x.remove(), hook_ls))
+            list(map(lambda x:x.remove() if x is not None else None, hook_ls))
 
             self.__measure_mem = True
 
@@ -164,15 +167,17 @@ class Meter:
 
     @property
     def ittp(self):
-        if len(self.ipt['args']) + len(self.ipt['kwargs']) == 0:
-            raise ValueError("Input unknown! You should perform at least one feed-forward inference before measuring the inference time or throughput!") 
+        if self._is_ipt_empty():
+            raise RuntimeError("Input unknown! You should perform at least one feed-forward inference before measuring the inference time or throughput!") 
+
+        self._ipt2device()
 
         for i in tqdm(range(self.ittp_warmup), desc='Warming Up'):
             self.model(*self.ipt['args'], **self.ipt['kwargs'])
 
         pb = tqdm(total=self.ittp_benchmark_time*len(self.optree.all_nodes), 
                   desc='Benchmark Inference Time & Throughput', 
-                  unit='time')
+                  unit='module')
         hook_ls = [node.ittp.measure(device=self.device, 
                                      repeat=self.ittp_benchmark_time,
                                      global_process=pb) 
@@ -182,12 +187,12 @@ class Meter:
         self.model(*self.ipt['args'], **self.ipt['kwargs']) 
 
         # remove hooks after measurement
-        list(map(lambda x:x.remove(), hook_ls))
+        list(map(lambda x:x.remove() if x is not None else None, hook_ls))
 
         return self.optree.root.ittp
 
     @property
-    def model_info(self):
+    def model_info(self) -> "rich.text.Text": # noqa # type: ignore
         forward_args:Tuple[str] = tuple(signature(self.model.forward).parameters.keys())
         ipt_dict = {forward_args[args_idx]: anony_ipt for args_idx, anony_ipt in enumerate(self.ipt['args'])}
         ipt_dict.update(self.ipt['kwargs'])
@@ -197,19 +202,35 @@ class Meter:
         infos = '\n'.join([
             f"• [b]Model    :[/b] {self.optree.root.name}",
             f"• [b]Device   :[/b] {self.device}",
-            f"• [b]Signature:[/b] forward(self, {','.join(forward_args)})",
-            f"• [b]Input    :[/b] \n{indent_str(ipt_repr, indent=5, guideline=False)}"
+            f"• [b]Signature:[/b] forward(self, {', '.join(forward_args)})",
+            f"• [b]Input    :[/b] \n{indent_str(ipt_repr, indent=3, guideline=False)}"
         ])
         
         console = get_console()
         return console.render_str(infos)
 
-    def stat_info(self, stat):
-        infos:List[str] = [f"• [b]Statistics:[/b] {stat.name}"]
-        if stat.name == 'ittp':
+    @property
+    def subnodes(self) -> List[str]:
+        return [f"({node.node_id}) {node.name}" for node in self.optree.all_nodes]
+
+    def rebase(self, node_id:str) -> "Meter":
+        id_generator = ( (node_idx, node.node_id) for node_idx, node in enumerate(self.optree.all_nodes) )
+
+        for idx, valid_id in id_generator:
+            if node_id == valid_id:
+                new_base = self.optree.all_nodes[idx]
+                return self.__class__(new_base.operation, device=self.device)
+        else:
+            raise ValueError(f"Invalid node_id: {node_id}. Use `Meter(your_model).subnodes` to check valid ones.")
+
+    def stat_info(self, stat_name:str):
+        stat = getattr(self, stat_name)
+
+        infos:List[str] = [f"• [b]Statistics:[/b] {stat_name}"]
+        if stat_name == 'ittp':
             infos.append(f"• [b]Benchmark Times:[/b] {self.ittp_benchmark_time}")
         infos.extend([
-            f"• [b]{k}:[/b] {v}" for k, v in stat.crucial_info.items()
+            f"• [b]{k}:[/b] {v}" for k, v in stat.crucial_data.items()
         ])
                     
         infos = '\n'.join(infos)
@@ -222,14 +243,15 @@ class Meter:
         
         order = order or self.optree.root.statistics
         
-        invalid_stat = tuple(filter(lambda x: not hasattr(self.optree.root, x), order))
-        assert len(invalid_stat) == 0, f"Invalid statistics: {invalid_stat}"
+        invalid_stat = tuple(filter(lambda x: x not in self.optree.root.statistics, order))
+        if len(invalid_stat) > 0:
+            raise AttributeError(f"Invalid statistics: {invalid_stat}")
         
         container = Columns(expand=True, align='center')
         format_cell = partial(Panel, safe_box=True, expand=False, highlight=True, box=HORIZONTALS)
         
         container.add_renderable(format_cell(self.model_info, title='[b]Model INFO[/]', border_style='orange1'))
-        container.renderables.extend([format_cell(self.stat_info(getattr(self, stat_name)), 
+        container.renderables.extend([format_cell(self.stat_info(stat_name), 
                                                   title=f"[b]{stat_name.capitalize()} INFO[/]",
                                                   border_style='cyan') 
                                       for stat_name in order])
@@ -237,7 +259,7 @@ class Meter:
         return container
 
     def profile(self, 
-                stat, 
+                stat_name:str, 
                 show=True, no_tree=False, 
                 **tb_kwargs):
         """To render a tabular profile of the statistics
@@ -263,7 +285,7 @@ class Meter:
 
         TREE_TABLE_GAP = __cfg__.combine.horizon_gap # the horizontal gap between tree and table
         
-        tb, data = self.table_renderer(stat_name=stat.name, **tb_kwargs)
+        tb, data = self.table_renderer(stat=getattr(self,stat_name), **tb_kwargs)
         
         if not show:
             return tb, data
@@ -276,7 +298,8 @@ class Meter:
         actual_tb_width = min(desirable_tb_width, console.width - tree_width - TREE_TABLE_GAP)
         
         if actual_tb_width <= 5: # 5 is the minimum width of table
-            raise ValueError("The width of the terminal is too small, try to maximize the window and try again.")
+            raise ValueError("The width of the terminal is too small, try to maximize the window or " + \
+                             "set a smaller `horizon_gap` value in your config and try again.")
         
         # when some cells in the table is overflown, we need to show a line between rows
         if actual_tb_width < desirable_tb_width:
@@ -285,18 +308,17 @@ class Meter:
         # get main content(i.e. tree & statistics table)
         if no_tree:
             main_content = tb
-            main_content_height = len(console.render_lines(tb))
-            main_content_width = actual_tb_width
+            tree_height = 0
         else:
             main_content = Layout()
             main_content.split_row(Layout(tree, name='left', size=tree_width + TREE_TABLE_GAP),
                                    Layout(tb, name='right', size=actual_tb_width))
-            
-            temp_options = console.options.update_width(actual_tb_width) 
             tree_height = len(console.render_lines(tree))
-            tb_height = len(console.render_lines(tb, options=temp_options))
-            main_content_height = max(tree_height, tb_height)
-            main_content_width = tree_width + TREE_TABLE_GAP + actual_tb_width
+        
+        temp_options = console.options.update_width(actual_tb_width) 
+        tb_height = len(console.render_lines(tb, options=temp_options))
+        main_content_height = max(tree_height, tb_height)
+        main_content_width = tree_width + actual_tb_width + (0 if no_tree else TREE_TABLE_GAP)
 
         # get footer content
         footer = Columns(title=Rule('[gray54]s u m m a r y[/]', characters='-', style='gray54'),
@@ -305,7 +327,7 @@ class Meter:
                          expand=True)
         
         model_info = self.model_info
-        stat_info = self.stat_info(stat)
+        stat_info = self.stat_info(stat_name=stat_name)
         model_info.style = 'dim'
         stat_info.style = 'dim'
         footer.add_renderable(model_info)
@@ -331,37 +353,25 @@ class Meter:
         
         return tb, data
 
-if __name__ == '__main__':
-    from rich import print
-    from torchvision import models
-    from torchmeter.config import get_config
-    
-    cfg = get_config()
-    model = models.resnet18()
-    
-    metered_model = Meter(model, device='cuda:0')
-    metered_model(torch.randn(1,3,224,224))
-    
-    cfg.tree_levels_args.default.guide_style = 'red'
-    print(metered_model.structure)
-    metered_model.tree_levels_args.default.guide_style = 'blue'
-    print(metered_model.structure)
-    # cfg.tree_levels_args.default.guide_style = 'red'
-    # cfg.table_display_args.style = 'red'
-    # metered_model.profile(metered_model.mem,
-    #                       show=True, no_tree=False,
-    #                       raw_data=False,
-    #                       custom_cols={'Operation_Id': 'Operation ID',
-    #                                    'Operation_Name': 'Operation Name',
-    #                                    'Param_Cost': 'Param Cost',
-    #                                    'FeatureMap_Cost': 'FeatureMap Cost'},
-    #                       pick_cols=['Operation_Id', 'Operation_Name', 
-    #                                  'Param_Cost','FeatureMap_Cost',
-    #                                  'Total'])
-                        #   newcol_name='Percentage',
-                        #   newcol_func=lambda col_dict,all_num=metered_model.mem.TotalCost.val: f'{col_dict["Total"]*100/all_num:.3f} %',
-                        #   newcol_dependcol=['Total'],
-                        #   newcol_type=str,
-                        #   newcol_idx=0,
-                        #   save_to='.',
-                        #   save_format='xlsx')
+    def _is_ipt_empty(self) -> bool:
+        return not self.ipt['args'] and not self.ipt['kwargs']
+        
+    def _ipt2device(self) -> None:
+        if self._is_ipt_empty():
+            raise ValueError("No input data provided.")
+
+        devices = set(arg.device for arg in self.ipt['args'] if isinstance(arg, Tensor))
+        devices.update(kwargs.device for kwargs in self.ipt['kwargs'].values() if isinstance(kwargs, Tensor))
+
+        if len(devices) == 1 and next(iter(devices)) == self.device:
+            return
+
+        self.ipt = {
+            'args': tuple(x.to(self.device) if isinstance(x, Tensor) else x 
+                          for x in self.ipt['args']),
+            'kwargs': {k: (v.to(self.device) if isinstance(v, Tensor) else v) 
+                       for k, v in self.ipt['kwargs'].items()}
+        }
+
+    def __repr__(self) -> str:
+        return f"Meter(model={self.optree}, device={self.device})"

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -12,9 +12,12 @@ from rich.layout import Layout
 from rich.columns import Columns
 from rich.box import HORIZONTALS
 
+from torchmeter.config import get_config
 from torchmeter.engine import OperationTree
 from torchmeter.utils import indent_str, data_repr
 from torchmeter.display import TreeRenderer, TabularRenderer, render_perline
+
+__cfg__ = get_config()
 
 class Meter:
 
@@ -221,7 +224,6 @@ class Meter:
     def profile(self, 
                 stat, 
                 show=True, no_tree=False, 
-                force_preset=False,
                 **tb_kwargs):
         """To render a tabular profile of the statistics
         
@@ -244,7 +246,7 @@ class Meter:
         
         """
 
-        TREE_TABLE_GAP = 2 # the horizontal gap between tree and table
+        TREE_TABLE_GAP = __cfg__.combine.horizon_gap # the horizontal gap between tree and table
         
         tb, data = self.table_renderer(stat_name=stat.name, **tb_kwargs)
         
@@ -262,7 +264,7 @@ class Meter:
             raise ValueError("The width of the terminal is too small, try to maximize the window and try again.")
         
         # when some cells in the table is overflown, we need to show a line between rows
-        if actual_tb_width < desirable_tb_width and not force_preset:
+        if actual_tb_width < desirable_tb_width:
             tb.show_lines = True 
         
         # get main content(i.e. tree & statistics table)

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -31,7 +31,7 @@ class Meter:
         elif isinstance(model, nn.Module):
             self.model = model.to(self.__device)
         else:
-            raise TypeError(f'model must be a torch.nn.Module or a path to a model, but got {type(model)}')
+            raise TypeError(f"model must be a torch.nn.Module or a path to a model, but got {type(model)}")
 
         self.ipt = {'args':tuple(), 'kwargs':dict()} # TODO: self.ipt_infer()
 
@@ -181,21 +181,21 @@ class Meter:
         ipt_repr = ',\n'.join(ipt_repr) 
 
         infos = '\n'.join([
-            f'• [b]Model    :[/b] {self.optree.root.name}',
-            f'• [b]Device   :[/b] {self.device}',
-            f'• [b]Signature:[/b] forward(self, {','.join(forward_args)})',
-            f'• [b]Input    :[/b] \n{indent_str(ipt_repr, len('• Inp'), guideline=False)}'
+            f"• [b]Model    :[/b] {self.optree.root.name}",
+            f"• [b]Device   :[/b] {self.device}",
+            f"• [b]Signature:[/b] forward(self, {','.join(forward_args)})",
+            f"• [b]Input    :[/b] \n{indent_str(ipt_repr, indent=5, guideline=False)}"
         ])
         
         console = get_console()
         return console.render_str(infos)
 
     def stat_info(self, stat):
-        infos:List[str] = [f'• [b]Statistics:[/b] {stat.name}']
+        infos:List[str] = [f"• [b]Statistics:[/b] {stat.name}"]
         if stat.name == 'ittp':
-            infos.append(f'• [b]Benchmark Times:[/b] {self.ittp_benchmark_time}')
+            infos.append(f"• [b]Benchmark Times:[/b] {self.ittp_benchmark_time}")
         infos.extend([
-            f'• [b]{k}:[/b] {v}' for k, v in stat.crucial_info.items()
+            f"• [b]{k}:[/b] {v}" for k, v in stat.crucial_info.items()
         ])
                     
         infos = '\n'.join(infos)
@@ -216,7 +216,7 @@ class Meter:
         
         container.add_renderable(format_cell(self.model_info, title='[b]Model INFO[/]', border_style='orange1'))
         container.renderables.extend([format_cell(self.stat_info(getattr(self, stat_name)), 
-                                                  title=f'[b]{stat_name.capitalize()} INFO[/]',
+                                                  title=f"[b]{stat_name.capitalize()} INFO[/]",
                                                   border_style='cyan') 
                                       for stat_name in order])
         

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -19,19 +19,15 @@ from torchmeter.display import TreeRenderer, TabularRenderer, render_perline
 class Meter:
 
     def __init__(self, 
-                 model: Union[nn.Module, str],
+                 model: nn.Module,
                  device:str='cpu',
                  verbose:bool=True):
         
         self.verbose = verbose
         self.__device = torch.device(device)
 
-        if isinstance(model, str):
-            self.model = torch.load(model, map_location=self.__device)
-        elif isinstance(model, nn.Module):
-            self.model = model.to(self.__device)
-        else:
-            raise TypeError(f"model must be a torch.nn.Module or a path to a model, but got {type(model)}")
+        assert isinstance(model, nn.Module), f"model must be a torch.nn.Module or a path to a model, but got {type(model)}"
+        self.model = model.to(self.__device)
 
         self.ipt = {'args':tuple(), 'kwargs':dict()} # TODO: self.ipt_infer()
 

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -61,11 +61,11 @@ class Meter:
 
     @property
     def tree_levels_args(self):
-        return self.tree_renderer.tree_level_args
+        return self.tree_renderer.tree_levels_args
     
     @tree_levels_args.setter
     def tree_levels_args(self, custom_args:Union[List[Dict[str, Any]], Dict[Any, Dict[str, Any]]]) -> None:
-        self.tree_renderer.tree_level_args = custom_args
+        self.tree_renderer.tree_levels_args = custom_args
 
     @property
     def tree_repeat_block_args(self):
@@ -342,12 +342,10 @@ if __name__ == '__main__':
     metered_model = Meter(model, device='cuda:0')
     metered_model(torch.randn(1,3,224,224))
     
-    import time
-    s=time.perf_counter()
-    metered_model.structure
     cfg.tree_levels_args.default.guide_style = 'red'
-    metered_model.structure
-    print(time.perf_counter()-s)
+    print(metered_model.structure)
+    metered_model.tree_levels_args.default.guide_style = 'blue'
+    print(metered_model.structure)
     # cfg.tree_levels_args.default.guide_style = 'red'
     # cfg.table_display_args.style = 'red'
     # metered_model.profile(metered_model.mem,

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -85,7 +85,7 @@ class Meter:
         self.optree.root.fold_repeat = fold_repeat
 
         self.tree_renderer = TreeRenderer(self.optree.root)
-        self.tb_renderer = TabularRenderer(self.optree.root)
+        self.table_renderer = TabularRenderer(self.optree.root)
 
         self.__measure_param = False
         self.__measure_cal = False
@@ -128,6 +128,22 @@ class Meter:
         self.__tree_rpblk_args = custom_args
         self.tree_renderer.render_fold_tree = None
         self.tree_renderer.render_unfold_tree = None
+
+    @property
+    def table_display_args(self):
+        return self.table_renderer.tb_args
+
+    @table_display_args.setter
+    def table_display_args(self, custom_args:Dict[str, Any]) -> None:
+        self.table_renderer.tb_args = custom_args
+
+    @property
+    def table_column_args(self):
+        return self.table_renderer.col_args
+
+    @table_column_args.setter
+    def table_column_args(self, custom_args:Dict[str, Any]) -> None:
+        self.table_renderer.col_args = custom_args
 
     @property
     def structure(self):
@@ -335,10 +351,7 @@ class Meter:
 
         TREE_TABLE_GAP = 2 # the horizontal gap between tree and table
         
-        tb_kwargs['table_settings'] = tb_kwargs.get('table_settings', self.tb_args)
-        tb_kwargs['column_settings'] = tb_kwargs.get('column_settings', self.tb_col_args)
-
-        tb, data = self.tb_renderer(stat_name=stat.name, **tb_kwargs)
+        tb, data = self.table_renderer(stat_name=stat.name, **tb_kwargs)
         
         if not show:
             return tb, data
@@ -420,12 +433,17 @@ if __name__ == '__main__':
     
     # print(metered_model.structure)
     # print(metered_model.mem)
-    print(metered_model.overview())
-    # metered_model.profile(metered_model.mem,
-    #                       show=True, no_tree=False,
-    #                       raw_data=False,)
-                        #   custom_cols={'Operation_Id': 'Operation ID'},
-                        #   pick_cols=['Operation_Id', 'Total'])
+    metered_model.table_display_args = {'style':'red'}
+    metered_model.profile(metered_model.mem,
+                          show=True, no_tree=False,
+                          raw_data=False,
+                          custom_cols={'Operation_Id': 'Operation ID',
+                                       'Operation_Name': 'Operation Name',
+                                       'Param_Cost': 'Param Cost',
+                                       'FeatureMap_Cost': 'FeatureMap Cost'},
+                          pick_cols=['Operation_Id', 'Operation_Name', 
+                                     'Param_Cost','FeatureMap_Cost',
+                                     'Total'])
                         #   newcol_name='Percentage',
                         #   newcol_func=lambda col_dict,all_num=metered_model.mem.TotalCost.val: f'{col_dict["Total"]*100/all_num:.3f} %',
                         #   newcol_dependcol=['Total'],

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -31,18 +31,6 @@ class Meter:
         self.render_time_sep = render_time_sep
         self.verbose = verbose
         self.__device = torch.device(device)
-        self.__tree_levels_args = {
-            '0':  {'label': '[b light_coral]<name>[/]', 
-                   'guide_style':'light_coral'}
-        }
-        self.__tree_rpblk_args = { 
-            'title': '[i]Repeat [[b]<repeat_time>[/b]] Times[/]',
-            'title_align': 'center',
-            'highlight': True,
-            'style': 'dark_goldenrod',
-            'border_style': 'dim',
-            'expand': False
-        }
         self.tb_col_args = {
             'justify': 'center',
             'vertical': 'middle',
@@ -111,23 +99,19 @@ class Meter:
 
     @property
     def tree_levels_args(self):
-        return self.__tree_levels_args
+        return self.tree_renderer.tree_level_args
     
     @tree_levels_args.setter
-    def tree_levels_args(self, custom_args:Dict[str, Any]) -> None:
-        self.__tree_levels_args = custom_args
-        self.tree_renderer.render_fold_tree = None
-        self.tree_renderer.render_unfold_tree = None
+    def tree_levels_args(self, custom_args:Union[List[Dict[str, Any]], Dict[Any, Dict[str, Any]]]) -> None:
+        self.tree_renderer.tree_level_args = custom_args
 
     @property
     def tree_repeat_block_args(self):
-        return self.__tree_rpblk_args
+        return self.tree_renderer.repeat_block_args
     
     @tree_repeat_block_args.setter
     def tree_repeat_block_args(self, custom_args:Dict[str, Any]) -> None:
-        self.__tree_rpblk_args = custom_args
-        self.tree_renderer.render_fold_tree = None
-        self.tree_renderer.render_unfold_tree = None
+        self.tree_renderer.repeat_block_args = custom_args
 
     @property
     def table_display_args(self):
@@ -150,9 +134,7 @@ class Meter:
         rendered_tree = self.tree_renderer.render_fold_tree if self.fold_repeat else self.tree_renderer.render_unfold_tree
         
         if rendered_tree is None:
-            rendered_tree = self.tree_renderer(fold_repeat=self.fold_repeat,
-                                               level_args=self.tree_levels_args,
-                                               repeat_block_args=self.tree_repeat_block_args)
+            rendered_tree = self.tree_renderer(fold_repeat=self.fold_repeat)
         
         # render_perline(renderable=rendered_tree)
         return rendered_tree
@@ -274,13 +256,13 @@ class Meter:
             'expand': False
         }
 
-        self.tb_col_args = {
+        self.table_column_args = {
             'justify': 'center',
             'vertical': 'middle',
             'overflow': 'fold'
         }
 
-        self.tb_args = {
+        self.table_display_args = {
             'style': 'spring_green4',
             'highlight': True,
 

--- a/torchmeter/core.py
+++ b/torchmeter/core.py
@@ -23,18 +23,16 @@ class Meter:
 
     def __init__(self, 
                  model: nn.Module,
-                 device:str='cpu',
-                 verbose:bool=True):
+                 device:str='cpu'):
         
-        self.verbose = verbose
         self.__device = torch.device(device)
 
-        assert isinstance(model, nn.Module), f"model must be a torch.nn.Module or a path to a model, but got {type(model)}"
+        assert isinstance(model, nn.Module), f"model must be an instance of torch.nn.Module, but got {type(model)}"
         self.model = model.to(self.__device)
 
         self.ipt = {'args':tuple(), 'kwargs':dict()} # TODO: self.ipt_infer()
 
-        self.optree = OperationTree(self.model, verbose=verbose)
+        self.optree = OperationTree(self.model)
 
         self.tree_renderer = TreeRenderer(self.optree.root)
         self.table_renderer = TabularRenderer(self.optree.root)

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -480,7 +480,7 @@ class TreeRenderer:
                     title = self.__resolve_argtext(text=getattr(self.repeat_block_args, 'title', ''), attr_owner=subject, 
                                                    loop_algebra=algebra)
                     repeat_block.__dict__.update({**self.repeat_block_args.__dict__, 
-                                                  'title':title, 
+                                                  'title':title,
                                                   'border_style': self.repeat_block_args.border_style + ' ' + self.repeat_block_args.style})
                     
                     # overwrite the label of the first node in repeat block 

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -4,7 +4,7 @@ import time
 import warnings
 from copy import copy,deepcopy
 from operator import attrgetter
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union, TypeVar
 
 from rich import print, get_console
 from rich.rule import Rule
@@ -12,19 +12,21 @@ from rich.tree import Tree
 from rich.panel import Panel
 from rich.segment import Segment
 from rich.table import Table, Column
-from rich.box import HEAVY_EDGE, ROUNDED
 from rich.console import Group, RenderableType
 from polars import DataFrame, struct, col
 from polars import List as pl_list, Object as pl_object
 
+from torchmeter.config import get_config, dict_to_namespace
 from torchmeter.utils import dfs_task, perfect_savepath
+
+__cfg__ = get_config()
+NAMESPACE_TYPE = TypeVar('NameSpace')
 
 def render_perline(renderable: Union[RenderableType, List[List[Segment]]],
                    line_prefix:'str'='',
                    line_suffix:'str'='',
                    row_separator:'str'='',
-                   console=None, 
-                   time_sep:float=0.15) -> None:
+                   console=None) -> None:
     """
     Output a renderable object line by line. \n
     Each line allows for the setting of a prefix and a suffix, i.e. `line_prefix` and `line_suffix`. \n
@@ -46,12 +48,11 @@ def render_perline(renderable: Union[RenderableType, List[List[Segment]]],
         - `console` (rich.console.Console, optional): The console object to be used for rendering. If it is not specified, 
                                                       the global console object will be used. Defaults to None.
         
-        - `time_sep` (float, optional): The time in second between each line output. Defaults to 0.15.
-    
     Returns:
     ---
         None
     """
+    time_sep = __cfg__.render_interval
     assert time_sep >= 0, f"Argument `time_sep` must be non-negative, but got {time_sep}"
     assert '\n' not in row_separator, "You don't have to add \\n manually in Argument `row_separator`, " + \
                                       "we will do it for you to ensure the correct display."
@@ -243,37 +244,27 @@ class TreeRenderer:
     def __init__(self, 
                  node:"OperationNode", # noqa # type: ignore 
                  loop_algebras:str='xyijkabcdefghlmnopqrstuvwz'):
-        self.opnode = deepcopy(node)
+        self.opnode = node
         self.loop_algebras:str = loop_algebras
 
         self.render_unfold_tree = None
         self.render_fold_tree = None
         
         # basic display format for a rendered tree
-        self.__default_level_args = {
+        self.__default_level_args:NAMESPACE_TYPE = getattr(__cfg__.tree_levels_args, 'default',
+        dict_to_namespace({
             'label':'[b gray35](<node_id>) [green]<name>[/green] [cyan]<type>[/]', # str | Callable
             'style':'tree',
             'guide_style':'light_coral',
             'highlight':True,
             'hide_root':False,
             'expanded':True
-        }
+        }))
         
-        self.__levels_args:Dict[Dict[str, Any]] = {
-            '0':  {'label': '[b light_coral]<name>[/]', # default display setting for root node
-                   'guide_style':'light_coral'}
-        }
+        self.__levels_args:NAMESPACE_TYPE = __cfg__.tree_levels_args
                 
         # basic display format for all repeat blocks in a rendered tree
-        self.__rpblk_args = { 
-            'title': '[i]Repeat [[b]<repeat_time>[/b]] Times[/]',
-            'title_align': 'center',
-            'highlight': True,
-            'style': 'dark_goldenrod',
-            'border_style': 'dim',
-            'box': HEAVY_EDGE,
-            'expand': False
-        }
+        self.__rpblk_args:NAMESPACE_TYPE = __cfg__.tree_repeat_block_args
         
         # basic format of footer in each repeat block
         def __default_rpft(attr_dict:dict) -> str:
@@ -290,15 +281,15 @@ class TreeRenderer:
         self.repeat_footer = __default_rpft 
         
     @property
-    def default_level_args(self) -> Dict[str, Any]:
+    def default_level_args(self) -> NAMESPACE_TYPE:
         return self.__default_level_args
     
     @property
-    def tree_level_args(self) -> Dict[str, Any]:
+    def tree_level_args(self) -> NAMESPACE_TYPE:
         return self.__levels_args
 
     @property
-    def repeat_block_args(self) -> Dict[str, Any]:
+    def repeat_block_args(self) -> NAMESPACE_TYPE:
         return self.__rpblk_args
 
     @default_level_args.setter
@@ -319,8 +310,9 @@ class TreeRenderer:
             raise TypeError(f'The new value of `TreeRenderer.default_level_args` must be a dict. But got {type(custom_args)}.')
         
         valid_setting_keys = tuple(Tree('.').__dict__.keys())
-        self.__default_level_args.update(custom_args)
-        self.__default_level_args = {k:v for k, v in self.__default_level_args.items() if k in valid_setting_keys}
+        _val_dict = self.__default_level_args.__dict__
+        _val_dict.update(custom_args)
+        _val_dict = {k:v for k, v in _val_dict.items() if k in valid_setting_keys}
 
     @tree_level_args.setter
     def tree_level_args(self, 
@@ -389,7 +381,7 @@ class TreeRenderer:
             else:
                 _custom_args[level] = level_args_dict
                
-        self.__levels_args = _custom_args
+        self.__levels_args.__dict__ = _custom_args
         
         self.render_fold_tree = None
         self.render_unfold_tree = None
@@ -416,12 +408,13 @@ class TreeRenderer:
             self.repeat_footer = custom_args[footer_key[-1]] 
         
         valid_setting_keys = tuple(Panel('.').__dict__.keys())
-        self.__rpblk_args.update(custom_args)
-        self.__rpblk_args = {k:v for k, v in self.__rpblk_args.items() 
-                                     if k in valid_setting_keys and k not in footer_key}
+        _val_dict = self.__rpblk_args.__dict__
+        _val_dict.update(custom_args)
+        _val_dict = {k:v for k, v in _val_dict.items() 
+                      if k in valid_setting_keys and k not in footer_key}
         self.render_fold_tree = None
 
-    def __call__(self, fold_repeat:bool=True) -> Tree:
+    def __call__(self) -> Tree:
         """Render the `OperationNode` object and its childs as a tree without polluting the original `OperationNode` object.
         
         see docs of the class(i.e. `torchmeter.display.TreeRenderer`) for details.
@@ -444,7 +437,9 @@ class TreeRenderer:
         ---
             see docs of the class(i.e. `torchmeter.display.TreeRenderer`) for details.
         """
-                
+        
+        fold_repeat:bool = __cfg__.tree_fold_repeat
+        
         # task_func for `dfs_task`
         def __apply_display_setting(subject:"OperationNode", # noqa # type: ignore
                                     pre_res=None) -> None:
@@ -460,7 +455,8 @@ class TreeRenderer:
             level = str(display_root.label)  
 
             # update display setting for the currently traversed node
-            target_level_args = self.tree_level_args.get(level, self.default_level_args)
+            target_level_args = getattr(self.tree_level_args, level, self.default_level_args)
+            target_level_args = target_level_args.__dict__
 
             # disolve label field
             origin_node_id = subject.node_id
@@ -531,7 +527,7 @@ class TreeRenderer:
                     if self.repeat_footer:
                         repeat_block_content = Group(
                             copy(display_root), # the tree structure of the circulating body
-                            Rule(characters='-', style=self.repeat_block_args.get('style','dim')), # a separator made up of '-'
+                            Rule(characters='-', style=getattr(self.repeat_block_args, 'style','none')), # a separator made up of '-'
                             self.__resolve_argtext(text=self.repeat_footer, attr_owner=subject, 
                                                  loop_algebra=loop_algebra, node_id=origin_node_id),
                             fit=True
@@ -541,9 +537,9 @@ class TreeRenderer:
                     
                     # make a pannel to show repeat information
                     repeat_block = Panel(repeat_block_content)
-                    title = self.__resolve_argtext(text=self.repeat_block_args.get('title', ''), attr_owner=subject, 
+                    title = self.__resolve_argtext(text=getattr(self.repeat_block_args, 'title', ''), attr_owner=subject, 
                                                    loop_algebra=loop_algebra)
-                    repeat_block.__dict__.update({**self.repeat_block_args, 'title':title})
+                    repeat_block.__dict__.update({**self.repeat_block_args.__dict__, 'title':title})
                     
                     # overwrite the label of the first node in repeat block 
                     subject.display_root.label = repeat_block
@@ -558,7 +554,8 @@ class TreeRenderer:
             return None
         
         # apply display setting for each node by dfs traversal
-        dfs_task(dfs_subject=self.opnode,
+        copy_tree = deepcopy(self.opnode)
+        dfs_task(dfs_subject=copy_tree,
                  adj_func=lambda x:x.childs.values(),
                  task_func=__apply_display_setting,
                  visited_signal_func=lambda x:str(id(x)),
@@ -570,7 +567,7 @@ class TreeRenderer:
         else:
             self.render_unfold_tree = self.opnode.display_root
         
-        return self.opnode.display_root
+        return copy_tree.display_root
 
     def resolve_attr(self, attr_val:Any) -> str:
         """
@@ -639,43 +636,16 @@ class TabularRenderer:
         self.__stats_data = {stat_name:DataFrame() for stat_name in node.statistics}
 
         # basic display format for each column
-        self.__default_col_args = {
-            'justify': 'center',
-            'vertical': 'middle',
-            'overflow': 'fold'
-        }
+        self.__default_col_args:NAMESPACE_TYPE = __cfg__.table_column_args
 
-        self.__default_tb_args = {
-            'style': 'spring_green4',
-            'highlight': True,
-
-            'title': None,
-            'title_style': 'bold',
-            'title_justify': 'center',
-            'title_align': 'center',
-
-            'show_header': True,
-            'header_style': 'bold',
-
-            'show_footer': False,
-            'footer_style': 'italic',
-
-            'show_lines': False,
-
-            'show_edge': True,
-            'box': ROUNDED,
-            'safe_box': True,
-
-            'expand': False,
-            'leading': 0,
-        }
+        self.__default_tb_args:NAMESPACE_TYPE = __cfg__.table_display_args
             
     @property
-    def tb_args(self):
+    def tb_args(self) -> NAMESPACE_TYPE:
         return self.__default_tb_args
     
     @property
-    def col_args(self):
+    def col_args(self) -> NAMESPACE_TYPE:
         return self.__default_col_args
 
     @property
@@ -692,8 +662,9 @@ class TabularRenderer:
             raise TypeError(f'The new value of `TabularRenderer.tb_args` must be a dict. But got {type(custom_args)}.')
     
         valid_setting_keys = tuple(Table().__dict__.keys())
-        self.__default_tb_args.update(custom_args)
-        self.__default_tb_args = {k:v for k, v in self.__default_tb_args.items() if k in valid_setting_keys}
+        _val_dict = self.__default_tb_args.__dict__
+        _val_dict.update(custom_args)
+        _val_dict = {k:v for k, v in _val_dict.items() if k in valid_setting_keys}
 
     @col_args.setter
     def col_args(self, custom_args:Dict[str, Any]):
@@ -701,8 +672,9 @@ class TabularRenderer:
             raise TypeError(f'The new value of `TabularRenderer.col_args` must be a dict. But got {type(custom_args)}.')
 
         valid_setting_keys = tuple(Column().__dict__.keys())
-        self.__default_col_args.update(custom_args)
-        self.__default_col_args = {k:v for k, v in self.__default_col_args.items() if k in valid_setting_keys}
+        _val_dict = self.__default_col_args.__dict__
+        _val_dict.update(custom_args)
+        _val_dict = {k:v for k, v in _val_dict.items() if k in valid_setting_keys}
 
     def __new_col(self, 
                   df:DataFrame,
@@ -732,11 +704,11 @@ class TabularRenderer:
         tb = Table(*tb_fields)
 
         # apply overall display settings
-        tb.__dict__.update(self.tb_args)
+        tb.__dict__.update(self.tb_args.__dict__)
 
         # apply column settings to all columns
         for tb_col in tb.columns:
-            tb_col.__dict__.update(self.col_args)
+            tb_col.__dict__.update(self.col_args.__dict__)
         
         # collect each column's none replacing string
         col_none_str = {col_name:getattr(df[col_name].drop_nulls().first(), 'none_str', '-') 

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -432,6 +432,9 @@ class TreeRenderer:
                 _custom_args[level] = level_args_dict
                
         self.__levels_args = _custom_args
+        
+        self.render_fold_tree = None
+        self.render_unfold_tree = None
 
     @repeat_block_args.setter
     def repeat_block_args(self, custom_args:Dict[str, Any]) -> None:
@@ -458,12 +461,9 @@ class TreeRenderer:
         self.__rpblk_args.update(custom_args)
         self.__rpblk_args = {k:v for k, v in self.__rpblk_args.items() 
                                      if k in valid_setting_keys and k not in footer_key}
+        self.render_fold_tree = None
 
-    def __call__(self,
-                 *,
-                 fold_repeat:bool=True,
-                 level_args:Union[List[Dict[str, Any]], Dict[Any, Dict[str, Any]]]={},
-                 repeat_block_args:Dict[str, Any]={}) -> Tree:
+    def __call__(self, fold_repeat:bool=True) -> Tree:
         """Render the `OperationNode` object and its childs as a tree without polluting the original `OperationNode` object.
         
         see docs of the class(i.e. `torchmeter.display.TreeRenderer`) for details.
@@ -486,20 +486,7 @@ class TreeRenderer:
         ---
             see docs of the class(i.e. `torchmeter.display.TreeRenderer`) for details.
         """
-        
-        assert isinstance(level_args, (list, dict)), f"Argument `level_args` must be a dict or a list of dicts, but got {type(level_args)}"
-        assert isinstance(repeat_block_args, dict), f"Argument `repeat_block_args` must be a dict, but got {type(repeat_block_args)}"
-        
-        # check, clean and apply `level_args`, 
-        if level_args:
-            self.tree_level_args = level_args
-        del level_args
-        
-        # check, clean and apply `repeat_block_args`
-        if repeat_block_args:
-            self.repeat_block_args = repeat_block_args
-        del repeat_block_args
-        
+                
         # task_func for `dfs_task`
         def __apply_display_setting(subject:"OperationNode", # noqa # type: ignore
                                     pre_res=None) -> None:

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -876,8 +876,6 @@ class TabularRenderer:
                  raw_data:bool=False,
                  pick_cols:List[str]=[],
                  custom_cols:Dict[str, str]={},
-                 table_settings:Dict[str, Any]={},
-                 column_settings:Dict[str, Any]={},
                  newcol_name:str='',
                  newcol_func:Callable[[Dict[str, Any]], Any]=lambda col_dict: col_dict,
                  newcol_dependcol:List[str]=[],
@@ -949,8 +947,6 @@ class TabularRenderer:
                                   col_idx=newcol_idx)
             self.datas[stat_name] = data
 
-        self.tb_args = table_settings
-        self.col_args = column_settings
         tb = self.df2tb(df=data, show_raw=raw_data)
 
         if save_to:

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -702,7 +702,7 @@ class TabularRenderer:
             print(f"Data saved to [b magenta]{file_path}[/]")
     
     def __call__(self,
-                 stat:"Statistic",  # noqa # type: ignore
+                 stat_name:str,
                  *, 
                  raw_data:bool=False,
                  pick_cols:List[str]=[],
@@ -718,8 +718,6 @@ class TabularRenderer:
         Note that `pick_cols` work before `custom_col`
         """
 
-        stat_name:"Statistic" = stat.name  # noqa # type: ignore
-
         if stat_name not in self.opnode.statistics:
             raise ValueError(f"`{stat_name}` not in the supported statistics {self.opnode.statistics}.")
         if not isinstance(newcol_idx, int):
@@ -728,8 +726,7 @@ class TabularRenderer:
             raise ValueError(f"`custom_cols` must be a dict, but got {type(custom_cols)}.")
         
         data:DataFrame = self.__stats_data[stat_name]
-
-        valid_fields = data.columns or stat.tb_fields
+        valid_fields = data.columns or getattr(self.opnode, stat_name).tb_fields
     
         def __fill_cell(subject:"OperationNode", # noqa # type: ignore
                         pre_res=None):

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -17,7 +17,7 @@ from polars import DataFrame, struct, col
 from polars import List as pl_list, Object as pl_object
 
 from torchmeter.config import get_config, dict_to_namespace
-from torchmeter.utils import dfs_task, perfect_savepath
+from torchmeter.utils import dfs_task, resolve_savepath
 
 __cfg__ = get_config()
 NAMESPACE_TYPE = TypeVar('NameSpace')
@@ -754,7 +754,7 @@ class TabularRenderer:
         assert format in self.valid_export_format, \
                 f"`{format}` file is not supported, now we only support exporting {self.valid_export_format} file."
         
-        _, file_path = perfect_savepath(origin_path=save_path,
+        _, file_path = resolve_savepath(origin_path=save_path,
                                        target_ext=format,
                                        default_filename=f"{self.opnode.name}_{file_suffix}") 
         

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -307,7 +307,7 @@ class TreeRenderer:
             - `TypeError`: if the new value is not a dict.
         """
         if not isinstance(custom_args, dict):
-            raise TypeError(f'The new value of `TreeRenderer.default_level_args` must be a dict. But got {type(custom_args)}.')
+            raise TypeError(f"The new value of `TreeRenderer.default_level_args` must be a dict. But got {type(custom_args)}.")
         
         valid_setting_keys = tuple(Tree('.').__dict__.keys())
         _val_dict = self.__default_level_args.__dict__
@@ -334,7 +334,7 @@ class TreeRenderer:
             `TypeError`: if the new value is not a dict or a list of dict.
         """
         if not isinstance(custom_args, (list, dict)):
-            raise TypeError(f'The new value of `TreeRenderer.tree_level_args` must be a dict or a list of dict. But got {type(custom_args)}.')
+            raise TypeError("The new value of `TreeRenderer.tree_level_args` must be a dict or a list of dict. But got {type(custom_args)}.")
         
         # convert to dict if input a list of dict
         if isinstance(custom_args, list):
@@ -401,7 +401,7 @@ class TreeRenderer:
             - `TypeError`: if the new value is not a dict.
         """
         if not isinstance(custom_args, dict):
-            raise TypeError(f'The new value of `TreeRenderer.repeat_block_args` must be a dict. But got {type(custom_args)}.')
+            raise TypeError(f"The new value of `TreeRenderer.repeat_block_args` must be a dict. But got {type(custom_args)}.")
         
         footer_key = list(filter(lambda x: x.lower() == 'repeat_footer', custom_args.keys()))
         if footer_key:
@@ -484,14 +484,14 @@ class TreeRenderer:
                         # update node_id with a algebraic expression which indicates the loop
                         if level != '1':
                            if loop_idx == 0:
-                               repeat_op_node.node_id = repeat_op_node.parent.node_id + f'.{loop_algebra}'
+                               repeat_op_node.node_id = repeat_op_node.parent.node_id + f".{loop_algebra}"
                            else:
-                               repeat_op_node.node_id = repeat_op_node.parent.node_id + f'.({loop_algebra}+{loop_idx})'
+                               repeat_op_node.node_id = repeat_op_node.parent.node_id + f".({loop_algebra}+{loop_idx})"
                         else:
                             if loop_idx == 0:
                                 repeat_op_node.node_id = loop_algebra
                             else:
-                                repeat_op_node.node_id = f'{loop_algebra}+{loop_idx}'
+                                repeat_op_node.node_id = f"{loop_algebra}+{loop_idx}"
                         
                         # disoolve label field for the `rich.Tree` object of the currently traversed node
                         label = self.__resolve_argtext(text=target_level_args['label'], attr_owner=repeat_op_node)
@@ -519,7 +519,7 @@ class TreeRenderer:
 
                     # update node_id with a algebraic expression which indicates the loop
                     if level != '1':
-                        subject.node_id = subject.parent.node_id + f'.{loop_algebra}'
+                        subject.node_id = subject.parent.node_id + f".{loop_algebra}"
                     else:
                         subject.node_id = loop_algebra
                     display_root.label = self.__resolve_argtext(text=target_level_args['label'], attr_owner=subject)
@@ -608,7 +608,7 @@ class TreeRenderer:
         
         if not isinstance(text, str):
             warnings.warn(message='The received text(see below) to be resolved is not a string, cannot go ahead.\n' + \
-                                  f'Type: {type(text)}\n Content: {text}',
+                                  f"Type: {type(text)}\n Content: {text}",
                           category=UserWarning)
 
         res_str = re.sub(pattern=r'(?<!\\)<(.*?)(?<!\\)>',
@@ -659,7 +659,7 @@ class TabularRenderer:
     @tb_args.setter
     def tb_args(self, custom_args:Dict[str, Any]):
         if not isinstance(custom_args, dict):
-            raise TypeError(f'The new value of `TabularRenderer.tb_args` must be a dict. But got {type(custom_args)}.')
+            raise TypeError(f"The new value of `TabularRenderer.tb_args` must be a dict. But got {type(custom_args)}.")
     
         valid_setting_keys = tuple(Table().__dict__.keys())
         _val_dict = self.__default_tb_args.__dict__
@@ -669,7 +669,7 @@ class TabularRenderer:
     @col_args.setter
     def col_args(self, custom_args:Dict[str, Any]):
         if not isinstance(custom_args, dict):
-            raise TypeError(f'The new value of `TabularRenderer.col_args` must be a dict. But got {type(custom_args)}.')
+            raise TypeError(f"The new value of `TabularRenderer.col_args` must be a dict. But got {type(custom_args)}.")
 
         valid_setting_keys = tuple(Column().__dict__.keys())
         _val_dict = self.__default_col_args.__dict__
@@ -686,7 +686,7 @@ class TabularRenderer:
         assert len(used_cols) > 0, 'You need to specify the columns used in the function for creating new columns, \
                                      and pass them to `newcol_dependcol` as a list.'
         for used_name in used_cols:
-            assert used_name in df.columns, f'Column `{used_name}` is not in the table.\nValid columns are {df.columns}.'
+            assert used_name in df.columns, f"Column `{used_name}` is not in the table.\nValid columns are {df.columns}."
 
         final_cols = df.columns[:]
         col_idx = (col_idx if col_idx >= 0 else len(df.columns)+col_idx+1) % (len(df.columns)+1)
@@ -747,16 +747,16 @@ class TabularRenderer:
         if format is None:
             format = os.path.splitext(save_path)[-1]
             assert '.' in format, 'File foramat unknown!\n' + \
-                                  f'Please specify a file path, not a dierectory path like {save_path}.\n' + \
-                                  f'Or specify a file format using `format=xxx`, now we support exporting to {self.valid_export_format} file.'
+                                  f"Please specify a file path, not a dierectory path like {save_path}.\n" + \
+                                  f"Or specify a file format using `format=xxx`, now we support exporting to {self.valid_export_format} file."
                                   
         format = format.strip('.')
         assert format in self.valid_export_format, \
-                f'`{format}` file is not supported, now we only support exporting {self.valid_export_format} file.'
+                f"`{format}` file is not supported, now we only support exporting {self.valid_export_format} file."
         
         _, file_path = perfect_savepath(origin_path=save_path,
                                        target_ext=format,
-                                       default_filename=f'{self.opnode.name}_{file_suffix}') 
+                                       default_filename=f"{self.opnode.name}_{file_suffix}") 
         
         # deal with invalid data
         df = deepcopy(df)
@@ -783,9 +783,9 @@ class TabularRenderer:
         
         # output saving message
         if file_suffix:
-            print(f'{file_suffix.capitalize()} data saved to [b magenta]{file_path}[/]')
+            print(f"{file_suffix.capitalize()} data saved to [b magenta]{file_path}[/]")
         else:
-            print(f'Data saved to [b magenta]{file_path}[/]')
+            print(f"Data saved to [b magenta]{file_path}[/]")
     
     def __call__(self,
                  stat_name:str, 
@@ -804,7 +804,7 @@ class TabularRenderer:
         Note that `pick_cols` work before `custom_col`
         """
         
-        assert isinstance(newcol_idx, int), f'`newcol_idx` must be an integer, but got {type(newcol_idx)}.'
+        assert isinstance(newcol_idx, int), f"`newcol_idx` must be an integer, but got {type(newcol_idx)}."
         assert stat_name in self.opnode.statistics, \
             f"`{stat_name}` not in the supported statistics {self.opnode.statistics}"
         
@@ -845,13 +845,13 @@ class TabularRenderer:
         # pick columns, order defined by `pick_cols`
         if pick_cols:
             invalid_cols = tuple(filter(lambda col_name:col_name not in data.columns, pick_cols))
-            assert not invalid_cols, f'Column names {invalid_cols} not found in supported columns {data.columns}.'
+            assert not invalid_cols, f"Column names {invalid_cols} not found in supported columns {data.columns}."
             data = data.select(pick_cols)
         
         # custom columns name, order defined by `custom_col`
         if custom_cols:
             invalid_cols = tuple(filter(lambda col_name:col_name not in data.columns, custom_cols.keys()))
-            assert not invalid_cols, f'Column names {invalid_cols} not found in supported columns {data.columns}.'
+            assert not invalid_cols, f"Column names {invalid_cols} not found in supported columns {data.columns}."
             data = data.rename(custom_cols)
         
         # add new column

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -556,10 +556,6 @@ class TabularRenderer:
         return __cfg__.table_column_args
 
     @property
-    def datas(self):
-        return self.__stats_data
-
-    @property
     def valid_export_format(self) -> List[str]:
         return ['csv', 'xlsx']
 
@@ -630,7 +626,7 @@ class TabularRenderer:
         if isinstance(stat_name,str):
             assert stat_name in valid_stat_name, \
                 f"`{stat_name}` not in the supported statistics {valid_stat_name}."
-            self.datas[stat_name] = DataFrame()
+            self.__stats_data[stat_name] = DataFrame()
         else:
             self.__stats_data = {stat_name:DataFrame() for stat_name in valid_stat_name}
 
@@ -710,7 +706,7 @@ class TabularRenderer:
         assert isinstance(custom_cols, dict), f"`custom_cols` must be a dict, but got {type(custom_cols)}."
         
         stat:"Statistic" = getattr(self.opnode, stat_name) # noqa # type: ignore
-        data:DataFrame = self.datas[stat_name]
+        data:DataFrame = self.__stats_data[stat_name]
 
         valid_fields = data.columns or stat.tb_fields
     
@@ -742,7 +738,7 @@ class TabularRenderer:
                      visited=[])
             
             data = DataFrame(data=val_collector, schema=valid_fields, orient='row')
-            self.datas[stat_name] = data
+            self.__stats_data[stat_name] = data
             
             if nocall_nodes:
                 warnings.warn(message=f"{', '.join(nocall_nodes)}\nThe modules above might be defined but not explicitly called. " + \
@@ -772,7 +768,7 @@ class TabularRenderer:
                                   col_func=newcol_func,
                                   return_type=newcol_type,
                                   col_idx=newcol_idx)
-            self.datas[stat_name] = data
+            self.__stats_data[stat_name] = data
 
         tb = self.df2tb(df=data, show_raw=raw_data)
 

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -19,48 +19,6 @@ from polars import List as pl_list, Object as pl_object
 
 from torchmeter.utils import dfs_task, perfect_savepath
 
-def indent_str(s:Union[str, Sequence[str]], 
-               indent:int=4, 
-               guideline:bool=True,
-               process_first:bool=True) -> str:
-    res = []
-    split_lines = s.split('\n') if isinstance(s, str) else s
-    guideline = False if len(split_lines) == 1 else guideline
-    
-    for line in split_lines:
-        indent_line = '│' if guideline else ' ' 
-        indent_line += ' '*(indent-1) + str(line)
-        res.append(indent_line)
-
-    if not process_first:
-        res[0] = res[0][indent:]
-
-    if guideline:
-        res[-1] = '└─' + res[-1][2:]
-    
-    return '\n'.join(res)
-
-def data_repr(val:Any):
-    get_type = lambda val: type(val).__name__
-
-    item_repr = lambda val_type, val: (f"[dim]Shape[/]([b green]{list(val.shape)}[/])" if hasattr(val, 'shape') else f"[b green]{val}[/]") + f" [dim]<{val_type}>[/]"
-
-    val_type = get_type(val)
-    if isinstance(val, (list, tuple, set, dict)) and len(val) > 0:
-        if isinstance(val, dict):
-            inner_repr:List[str] = [f'{item_repr(get_type(k),k)}: {data_repr(v)}' for k, v in val.items()]
-        else:
-            inner_repr:List[str] = [data_repr(i) for i in val]
-        
-        res_repr = f'[dim]{val_type}[/](' 
-        res_repr += ',\n'.join(inner_repr)
-        res_repr += ')'
-
-        return indent_str(res_repr, indent=len(f'{val_type}('), process_first=False)
-    
-    else:
-        return item_repr(val_type, val)
-
 def render_perline(renderable: Union[RenderableType, List[List[Segment]]],
                    line_prefix:'str'='',
                    line_suffix:'str'='',
@@ -573,7 +531,7 @@ class TreeRenderer:
                     if self.repeat_footer:
                         repeat_block_content = Group(
                             copy(display_root), # the tree structure of the circulating body
-                            Rule(characters='-', style=self.repeat_block_args.get('style','')), # a separator made up of '-'
+                            Rule(characters='-', style=self.repeat_block_args.get('style','dim')), # a separator made up of '-'
                             self.__resolve_argtext(text=self.repeat_footer, attr_owner=subject, 
                                                  loop_algebra=loop_algebra, node_id=origin_node_id),
                             fit=True

--- a/torchmeter/display.py
+++ b/torchmeter/display.py
@@ -692,6 +692,7 @@ class TabularRenderer:
                  *, 
                  raw_data:bool=False,
                  pick_cols:List[str]=[],
+                 exclude_cols:List[str]=[],
                  custom_cols:Dict[str, str]={},
                  newcol_name:str='',
                  newcol_func:Callable[[Dict[str, Any]], Any]=lambda col_dict: col_dict,
@@ -750,9 +751,13 @@ class TabularRenderer:
         
         # pick columns, order defined by `pick_cols`
         if pick_cols:
-            invalid_cols = tuple(filter(lambda col_name:col_name not in data.columns, pick_cols))
+            invalid_cols = tuple(filter(lambda col_name:col_name not in valid_fields, pick_cols))
             assert not invalid_cols, f"Column names {invalid_cols} not found in supported columns {data.columns}."
-            data = data.select(pick_cols)
+        else:
+            pick_cols = valid_fields
+        # not use set is to keep order
+        final_cols = [col_name for col_name in pick_cols if col_name not in exclude_cols] 
+        data = data.select(final_cols)
         
         # custom columns name, order defined by `custom_col`
         if custom_cols:

--- a/torchmeter/engine.py
+++ b/torchmeter/engine.py
@@ -8,7 +8,7 @@ from rich.tree import Tree
 from torchmeter.utils import dfs_task, Timer
 from torchmeter.statistic import ParamsMeter, CalMeter, MemMeter, ITTPMeter
 
-__all__ = ('OperationNode', 'OperationTree')
+__all__ = ["OperationNode", "OperationTree"]
 
 class OperationNode:
    
@@ -65,7 +65,7 @@ class OperationNode:
         return self.__ittp
     
     def __repr__(self):
-        op_str = str(self.type) if self.is_leaf else str(self.operation)            
+        op_str = str(self.type) if not self.is_leaf else str(self.operation)            
         return f"{self.node_id} {self.name}: {op_str}"
     
 class OperationTree:

--- a/torchmeter/engine.py
+++ b/torchmeter/engine.py
@@ -8,10 +8,12 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch.nn as nn
 from rich.tree import Tree
 
+from torchmeter.config import get_config
 from torchmeter.utils import dfs_task, Verboser
 from torchmeter.statistic import ParamsMeter, CalMeter, MemMeter, ITTPMeter
 
 __all__ = ('OperationNode', 'OperationTree')
+__cfg__ = get_config()
 
 class OperationNode:
    
@@ -44,8 +46,7 @@ class OperationNode:
         
         # display info 
         self.display_root:Tree = None # set in `OperationTree.__build()`
-        self.fold_repeat = True # TODO: move to a supper level
-        self.render_when_repeat = False # whether to render when enable `fold_repeat` in `render_as_tree`, set in `OperationTree.__build()`
+        self.render_when_repeat = False # whether to render when enable `fold_repeat`, set in `OperationTree.__build()`
         self.is_folded = False # whether the node is folded in a repeat block, set in `OperationTree.__build()`
 
         self.level_args:List[Dict[str, str]] = []

--- a/torchmeter/engine.py
+++ b/torchmeter/engine.py
@@ -63,7 +63,7 @@ class OperationNode:
             if key in self.__dict__:
                 setattr(self, key, value)
             else:
-                warnings.warn(f'`{key}` is not a valid attribute of `OperationNode`, ignored.')
+                warnings.warn(f"`{key}` is not a valid attribute of `OperationNode`, ignored.")
 
     @property
     def param(self) -> ParamsMeter:
@@ -116,7 +116,7 @@ class OperationTree:
                                          task_func=OperationTree.__build,
                                          visited_signal_func=lambda x:x.addr,
                                          visited=[])
-            vb.exit_text = f'[b blue][green]{time.time()-start:.3f}[/green] seconds\n[/]'
+            vb.exit_text = f"[b blue][green]{time.time()-start:.3f}[/green] seconds\n[/]"
 
         self.all_nodes = [self.root] + nonroot_nodes
             

--- a/torchmeter/engine.py
+++ b/torchmeter/engine.py
@@ -1,5 +1,4 @@
 import re
-import time
 import warnings
 from copy import deepcopy
 from collections import OrderedDict
@@ -8,12 +7,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch.nn as nn
 from rich.tree import Tree
 
-from torchmeter.config import get_config
-from torchmeter.utils import dfs_task, Verboser
+from torchmeter.utils import dfs_task, Timer
 from torchmeter.statistic import ParamsMeter, CalMeter, MemMeter, ITTPMeter
 
 __all__ = ('OperationNode', 'OperationTree')
-__cfg__ = get_config()
 
 class OperationNode:
    
@@ -106,17 +103,12 @@ class OperationTree:
                                   node_id="0",
                                   render_when_repeat=True)
         
-        with Verboser(enable=verbose,
-                      enter_text='[b blue]Scaning model in ',
-                      enter_args={'end':''}) as vb:
-            start = time.time()
-            # all_nodes: List[OperationNode], a list holding all operation nodes but the root
+        with Timer(task_desc="Scanning model"):
             nonroot_nodes, *_ = dfs_task(dfs_subject=self.root, 
                                          adj_func=lambda x:x.childs.values(),
                                          task_func=OperationTree.__build,
                                          visited_signal_func=lambda x:x.addr,
                                          visited=[])
-            vb.exit_text = f"[b blue][green]{time.time()-start:.3f}[/green] seconds\n[/]"
 
         self.all_nodes = [self.root] + nonroot_nodes
             

--- a/torchmeter/engine.py
+++ b/torchmeter/engine.py
@@ -77,7 +77,8 @@ class OperationTree:
         with Timer(task_desc="Scanning model"):
             nonroot_nodes, *_ = dfs_task(dfs_subject=self.root, 
                                          adj_func=lambda x:x.childs.values(),
-                                         task_func=OperationTree.__build)
+                                         task_func=OperationTree.__build,
+                                         visited=[])
 
         self.all_nodes = [self.root] + nonroot_nodes
             

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -348,7 +348,9 @@ class CalMeter(Statistics):
 
     def __is_valid_access(self):
         if self.is_measured:
-            if not (self.Flops.val + self.Macs.val) and not self.__stat_ls:
+            if not (self.Flops.val + self.Macs.val) and \
+               not self.__stat_ls and \
+               not isinstance(self._model, (nn.ModuleDict, nn.ModuleList)):
                 raise RuntimeError("This module might be defined but not explicitly called, so no data is collected.")
         else:
             raise AttributeError("You should never access this property on your own " + \
@@ -617,7 +619,7 @@ class MemMeter(Statistics):
 
     def __is_valid_access(self):
         if self.is_measured:
-            if not self.__stat_ls:
+            if not self.__stat_ls and not isinstance(self._model, (nn.ModuleDict, nn.ModuleList)):
                 raise RuntimeError("This module might be defined but not explicitly called, so no data is collected.")
         else:
             raise AttributeError("You should never access this property on your own " + \
@@ -738,7 +740,7 @@ class ITTPMeter(Statistics):
 
     def __is_valid_access(self):
         if self.is_measured:
-            if not self.__stat_ls:
+            if not self.__stat_ls and not isinstance(self._model, (nn.ModuleDict, nn.ModuleList)):
                 raise RuntimeError("This module might be defined but not explicitly called, so no data is collected.")
         else:
             raise AttributeError("You should never access this property on your own " + \

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -18,7 +18,7 @@ OPN_TYPE = TypeVar("OperationNode")
 
 class UpperLinkData:
 
-    __slots__ = ['val', 'none_str',
+    __slots__ = ['val', 'none_str', 'access_cnt',
                  '__parent_data', '__unit_sys']
 
     def __init__(self, 
@@ -28,6 +28,7 @@ class UpperLinkData:
         self.val = val
         self.__parent_data = parent_data    
         self.__unit_sys = unit_sys
+        self.access_cnt = 1
         self.none_str = none_str # Use when there is a "None" in the column where this data is located while rendering the table.
     
     @property
@@ -37,6 +38,7 @@ class UpperLinkData:
     def __iadd__(self, other):
         self.val += other
         self.__upper_update(other)
+        # self.access_cnt += 1
         return self
     
     def __upper_update(self, other:int):
@@ -45,9 +47,10 @@ class UpperLinkData:
     
     def __repr__(self):
         if self.__unit_sys is not None:
-            return auto_unit(self.val, self.__unit_sys)
+            base = auto_unit(self.val/self.access_cnt, self.__unit_sys)
         else:
-            return str(self.val)
+            base = str(self.val/self.access_cnt)
+        return base + (f"[dim]\nx {self.access_cnt}[/]" if self.access_cnt > 1 else "")
 
 class MetricsData:
 
@@ -389,16 +392,20 @@ class CalMeter(Statistics):
         self.__Macs += MACs
         self.__Flops += FLOPs
         
-        self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                        Operation_Name=self._opnode.name,
-                                                        Operation_Type=self._opnode.type,
-                                                        Kernel_Size=list(module.kernel_size),
-                                                        Bias=bool(is_bias),
-                                                        Input_Shape=list(input[0].shape),
-                                                        Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs,
-                                                        FLOPs=self.Flops)
-        )
+        if len(self.__stat_ls):
+            self.Macs.access_cnt += 1
+            self.Flops.access_cnt += 1
+        else:
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type,
+                                                            Kernel_Size=list(module.kernel_size),
+                                                            Bias=bool(is_bias),
+                                                            Input_Shape=list(input[0].shape),
+                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            MACs=self.Macs,
+                                                            FLOPs=self.Flops)
+            )
     
     def __linear_hook(self, module, input, output):
         k = module.in_features
@@ -411,15 +418,19 @@ class CalMeter(Statistics):
         self.__Macs += MACs
         self.__Flops += FLOPs
 
-        self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                        Operation_Name=self._opnode.name,
-                                                        Operation_Type=self._opnode.type,
-                                                        Bias=bool(is_bias),
-                                                        Input_Shape=list(input[0].shape),
-                                                        Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs,
-                                                        FLOPs=self.Flops)
-        )
+        if len(self.__stat_ls):
+            self.Macs.access_cnt += 1
+            self.Flops.access_cnt += 1
+        else:
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type,
+                                                            Bias=bool(is_bias),
+                                                            Input_Shape=list(input[0].shape),
+                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            MACs=self.Macs,
+                                                            FLOPs=self.Flops)
+            )
 
     def __BN_hook(self, module, input, output):
         FLOPs = 4*input[0].numel()
@@ -427,14 +438,18 @@ class CalMeter(Statistics):
         self.__Macs += MACs
         self.__Flops += FLOPs
 
-        self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                        Operation_Name=self._opnode.name,
-                                                        Operation_Type=self._opnode.type,
-                                                        Input_Shape=list(input[0].shape),
-                                                        Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs,
-                                                        FLOPs=self.Flops)
-        )
+        if len(self.__stat_ls):
+            self.Macs.access_cnt += 1
+            self.Flops.access_cnt += 1
+        else:
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type,
+                                                            Input_Shape=list(input[0].shape),
+                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            MACs=self.Macs,
+                                                            FLOPs=self.Flops)
+            )
 
     def __activate_hook(self, module, input, output):
         k = input[0].numel()
@@ -457,14 +472,18 @@ class CalMeter(Statistics):
         self.__Macs += MACs
         self.__Flops += FLOPs
 
-        self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                        Operation_Name=self._opnode.name,
-                                                        Operation_Type=self._opnode.type,
-                                                        Input_Shape=list(input[0].shape),
-                                                        Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs,
-                                                        FLOPs=self.Flops)
-        )
+        if len(self.__stat_ls):
+            self.Macs.access_cnt += 1
+            self.Flops.access_cnt += 1
+        else:
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type,
+                                                            Input_Shape=list(input[0].shape),
+                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            MACs=self.Macs,
+                                                            FLOPs=self.Flops)
+            )
 
     def __pool_hook(self, module, input, output):
         k = module.kernel_size
@@ -481,23 +500,28 @@ class CalMeter(Statistics):
         self.__Macs += MACs
         self.__Flops += FLOPs
 
-        self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                        Operation_Name=self._opnode.name,
-                                                        Operation_Type=self._opnode.type,
-                                                        Kernel_Size=list(k) if len(k)>1 else [k[0]]*2,
-                                                        Input_Shape=list(input[0].shape),
-                                                        Output_Shape=[len(output)]+list(output[0].shape),
-                                                        MACs=self.Macs,
-                                                        FLOPs=self.Flops)
-        )
+        if len(self.__stat_ls):
+            self.Macs.access_cnt += 1
+            self.Flops.access_cnt += 1
+        else:
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type,
+                                                            Kernel_Size=list(k) if len(k)>1 else [k[0]]*2,
+                                                            Input_Shape=list(input[0].shape),
+                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            MACs=self.Macs,
+                                                            FLOPs=self.Flops)
+            )
 
     def __not_support_hook(self, module, input, output):
-        self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                        Operation_Name=self._opnode.name,
-                                                        Operation_Type=self._opnode.type,
-                                                        Input_Shape=list(input[0].shape),
-                                                        Output_Shape=[len(output)]+list(output[0].shape))
-        )
+        if not len(self.__stat_ls):
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type,
+                                                            Input_Shape=list(input[0].shape),
+                                                            Output_Shape=[len(output)]+list(output[0].shape))
+            )
 
 class MemMeter(Statistics):
 
@@ -526,7 +550,7 @@ class MemMeter(Statistics):
         self._model = opnode.operation
         self.is_inplace = getattr(self._model, 'inplace', False)
         
-        self.__stat_ls = set() # use set not list to avoid duplicate access
+        self.__stat_ls = [] # record the flops and macs information of each operation
         self.is_measured = False # used for cache
 
         _opparent = opnode.parent
@@ -611,16 +635,21 @@ class MemMeter(Statistics):
             feat_cost = 0
         self.__FeatureMapCost += feat_cost
         
-        total_cost = param_cost + buffer_cost + feat_cost
-        self.__TotalCost += total_cost
+        if len(self.__stat_ls):
+            # duplicated access
+            self.FeatureMapCost.access_cnt += 1
+            total_cost = feat_cost
+        else:
+            total_cost = param_cost + buffer_cost + feat_cost
+            self.__stat_ls.append(self.detail_val_container(Operation_Id=self._opnode.node_id,
+                                                            Operation_Name=self._opnode.name,
+                                                            Operation_Type=self._opnode.type + ('(inplace)' if self.is_inplace else ''),
+                                                            Param_Cost=None if self._opnode.is_leaf and not param_cost else self.ParamCost, 
+                                                            Buffer_Cost=None if self._opnode.is_leaf and not buffer_cost else self.BufferCost, 
+                                                            FeatureMap_Cost=None if self._opnode.is_leaf and not feat_cost else self.FeatureMapCost, 
+                                                            Total=None if self._opnode.is_leaf and not total_cost else self.TotalCost))
         
-        self.__stat_ls.add(self.detail_val_container(Operation_Id=self._opnode.node_id,
-                                                     Operation_Name=self._opnode.name + ('(inplace)' if self.is_inplace else ''),
-                                                     Operation_Type=self._opnode.type,
-                                                     Param_Cost=None if self._opnode.is_leaf and not param_cost else self.ParamCost, 
-                                                     Buffer_Cost=None if self._opnode.is_leaf and not buffer_cost else self.BufferCost, 
-                                                     FeatureMap_Cost=None if self._opnode.is_leaf and not feat_cost else self.FeatureMapCost, 
-                                                     Total=self.TotalCost if total_cost else None))
+        self.__TotalCost += total_cost
 
     def __is_valid_access(self):
         if self.is_measured:

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -142,7 +142,7 @@ class Statistics(ABC):
         if opparent is None:
             link_data = UpperLinkData(val=init_val, **kwargs)
         else:
-            upper_getter = attrgetter(f'{self.name}.{attr_name}')
+            upper_getter = attrgetter(f"{self.name}.{attr_name}")
             link_data = UpperLinkData(val=init_val, 
                                       parent_data=upper_getter(opparent),
                                       **kwargs)
@@ -539,10 +539,10 @@ class MemMeter(Statistics):
     
     @property
     def crucial_info(self) -> Dict[str, str]:
-        res_dict =  {'[b]Parameters[/] Memory Cost': f'{self.ParamCost}, {self.ParamCost.val*100/self.TotalCost.val:.2f} %',
-                     '[b]Buffers[/] Memory Cost': f'{self.BufferCost}, {self.BufferCost.val*100/self.TotalCost.val:.2f} %',
-                     '[b]FeatureMap[/] Memory Cost': f'{self.FeatureMapCost}, {self.FeatureMapCost.val*100/self.TotalCost.val:.2f} %',
-                     '[b]Total Memory Cost[/]': f'{self.TotalCost}'}
+        res_dict =  {'[b]Parameters[/] Memory Cost': f"{self.ParamCost}, {self.ParamCost.val*100/self.TotalCost.val:.2f} %",
+                     '[b]Buffers[/] Memory Cost': f"{self.BufferCost}, {self.BufferCost.val*100/self.TotalCost.val:.2f} %",
+                     '[b]FeatureMap[/] Memory Cost': f"{self.FeatureMapCost}, {self.FeatureMapCost.val*100/self.TotalCost.val:.2f}",
+                     '[b]Total Memory Cost[/]': str(self.TotalCost)}
         max_keylen = max([len(key) for key in res_dict.keys()])
         res_dict = {key.ljust(max_keylen): value for key, value in res_dict.items()}
         return res_dict

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -12,7 +12,7 @@ from torch.cuda import Event as cuda_event
 from torch.cuda import synchronize as cuda_sync
 
 from torchmeter.unit import UNIT_TYPE, auto_unit
-from torchmeter.unit import CountUnit, DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit
+from torchmeter.unit import CountUnit, BinaryUnit, TimeUnit, SpeedUnit
 
 OPN_TYPE = TypeVar("OperationNode")
 
@@ -55,7 +55,7 @@ class MetricsData:
                  'reduce_func',
                  '__unit_sys']
 
-    def __init__(self, reduce_func:Optional[Callable]=np.mean, unit_sys:Optional[UNIT_TYPE]=DecimalUnit):
+    def __init__(self, reduce_func:Optional[Callable]=np.mean, unit_sys:Optional[UNIT_TYPE]=CountUnit):
         self.vals = np.array([])
         self.reduce_func = reduce_func if reduce_func is not None else lambda x:x
         self.__unit_sys = unit_sys
@@ -287,9 +287,9 @@ class CalMeter(Statistics):
 
         _opparent = opnode.parent
         self.__Macs = self.init_linkdata(attr_name='Macs', init_val=0, opparent=_opparent, 
-                                         unit_sys=DecimalUnit, none_str='Not Supported')
+                                         unit_sys=CountUnit, none_str='Not Supported')
         self.__Flops = self.init_linkdata(attr_name='Flops', init_val=0, opparent=_opparent, 
-                                          unit_sys=DecimalUnit, none_str='Not Supported')
+                                          unit_sys=CountUnit, none_str='Not Supported')
 
     @property
     def name(self) -> str:

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -403,7 +403,7 @@ class CalMeter(Statistics):
                                                             Kernel_Size=list(module.kernel_size),
                                                             Bias=bool(is_bias),
                                                             Input_Shape=list(input[0].shape),
-                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            Output_Shape=list(output.shape),
                                                             MACs=self.Macs,
                                                             FLOPs=self.Flops)
             )
@@ -428,7 +428,7 @@ class CalMeter(Statistics):
                                                             Operation_Type=self._opnode.type,
                                                             Bias=bool(is_bias),
                                                             Input_Shape=list(input[0].shape),
-                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            Output_Shape=list(output.shape),
                                                             MACs=self.Macs,
                                                             FLOPs=self.Flops)
             )
@@ -447,7 +447,7 @@ class CalMeter(Statistics):
                                                             Operation_Name=self._opnode.name,
                                                             Operation_Type=self._opnode.type,
                                                             Input_Shape=list(input[0].shape),
-                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            Output_Shape=list(output.shape),
                                                             MACs=self.Macs,
                                                             FLOPs=self.Flops)
             )
@@ -481,7 +481,7 @@ class CalMeter(Statistics):
                                                             Operation_Name=self._opnode.name,
                                                             Operation_Type=self._opnode.type,
                                                             Input_Shape=list(input[0].shape),
-                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            Output_Shape=list(output.shape),
                                                             MACs=self.Macs,
                                                             FLOPs=self.Flops)
             )
@@ -510,7 +510,7 @@ class CalMeter(Statistics):
                                                             Operation_Type=self._opnode.type,
                                                             Kernel_Size=list(k) if len(k)>1 else [k[0]]*2,
                                                             Input_Shape=list(input[0].shape),
-                                                            Output_Shape=[len(output)]+list(output[0].shape),
+                                                            Output_Shape=list(output.shape),
                                                             MACs=self.Macs,
                                                             FLOPs=self.Flops)
             )
@@ -521,7 +521,7 @@ class CalMeter(Statistics):
                                                             Operation_Name=self._opnode.name,
                                                             Operation_Type=self._opnode.type,
                                                             Input_Shape=list(input[0].shape),
-                                                            Output_Shape=[len(output)]+list(output[0].shape))
+                                                            Output_Shape=list(output.shape))
             )
 
 class MemMeter(Statistics):

--- a/torchmeter/statistic.py
+++ b/torchmeter/statistic.py
@@ -15,6 +15,8 @@ from torch.cuda import synchronize as cuda_sync
 from torchmeter.unit import UNIT_TYPE, auto_unit
 from torchmeter.unit import CountUnit, BinaryUnit, TimeUnit, SpeedUnit
 
+__all__ = ["ParamsMeter", "CalMeter", "MemMeter", "ITTPMeter"]
+
 OPN_TYPE = TypeVar("OperationNode")
 
 class UpperLinkData:
@@ -51,7 +53,7 @@ class UpperLinkData:
             base = auto_unit(self.val/self.access_cnt, self.__unit_sys)
         else:
             base = str(self.val/self.access_cnt)
-        return base + (f"[dim]\nx {self.access_cnt}[/]" if self.access_cnt > 1 else "")
+        return base + (f" [dim](×{self.access_cnt})[/]" if self.access_cnt > 1 else "")
 
 class MetricsData:
 
@@ -102,10 +104,10 @@ class MetricsData:
 class Statistics(ABC):
 
     def __new__(cls, *args, **kwargs):
-        assert hasattr(cls, 'detail_val_container'), \
-            f"Class '{cls.__name__}' must have the class attribute 'detail_val_container', which should be a NamedTuple"
-        assert hasattr(cls, 'overview_val_container'), \
-            f"Class '{cls.__name__}' must have the class attribute 'overview_val_container', which should be a NamedTuple"
+        if not hasattr(cls, 'detail_val_container'):
+            raise AttributeError(f"Class '{cls.__name__}' must have the class attribute 'detail_val_container', which should be a NamedTuple")
+        if not hasattr(cls, 'overview_val_container'):
+            raise AttributeError(f"Class '{cls.__name__}' must have the class attribute 'overview_val_container', which should be a NamedTuple")
         return super().__new__(cls)        
 
     @property

--- a/torchmeter/unit.py
+++ b/torchmeter/unit.py
@@ -47,7 +47,7 @@ def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> Union[str, None
     for unit in list(unit_system):
         if val >= unit.value:
             if val % unit.value:
-                return f'{val / unit.value:.2f} {unit.name}'
+                return f"{val / unit.value:.2f} {unit.name}"
             else:
-                return f'{val // unit.value} {unit.name}'
+                return f"{val // unit.value} {unit.name}"
     return str(val)

--- a/torchmeter/unit.py
+++ b/torchmeter/unit.py
@@ -1,6 +1,9 @@
 from typing import Union
 from enum import Enum, IntEnum, IntFlag, unique
 
+__all__ = ["CountUnit", "BinaryUnit", "TimeUnit", "SpeedUnit",
+           "auto_unit"]
+
 @unique
 class CountUnit(IntEnum):
     T:int = 1e12

--- a/torchmeter/unit.py
+++ b/torchmeter/unit.py
@@ -2,14 +2,6 @@ from typing import Union
 from enum import Enum, IntEnum, IntFlag, unique
 
 @unique
-class DecimalUnit(IntEnum):
-    T:int = 1e12
-    G:int = 1e9
-    M:int = 1e6
-    K:int = 1e3
-    B:int = 1e0
-
-@unique
 class CountUnit(IntEnum):
     T:int = 1e12
     G:int = 1e9
@@ -41,13 +33,16 @@ class SpeedUnit(IntEnum):
     KSamPS:int = 1e3
     SamPS:int  = 1e0
 
-UNIT_TYPE = Union[DecimalUnit, BinaryUnit, TimeUnit, SpeedUnit]
+UNIT_TYPE = Union[CountUnit, BinaryUnit, TimeUnit, SpeedUnit]
 
-def auto_unit(val:Union[int, float], unit_system=DecimalUnit) -> Union[str, None]:
+def auto_unit(val:Union[int, float], unit_system=CountUnit) -> str:
     for unit in list(unit_system):
         if val >= unit.value:
             if val % unit.value:
                 return f"{val / unit.value:.2f} {unit.name}"
             else:
                 return f"{val // unit.value} {unit.name}"
-    return str(val)
+    if isinstance(val, int):
+        return str(val)
+    else:
+        return f"{val:.2f}"

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -6,6 +6,9 @@ from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 from rich.status import Status
 
+__all__ = ["dfs_task", "dfs_task", "data_repr",
+           "Timer"]
+
 def resolve_savepath(origin_path:str, 
                      target_ext:str,
                      default_filename:str='Data'):
@@ -45,7 +48,8 @@ def hasargs(func:Callable, *required_args:Tuple[str]) -> None:
     missing_args = [arg for arg in required_args 
                         if arg not in signature(func).parameters]
     
-    assert not missing_args, f"Function `{func.__name__}()` is missing follewing required args: {missing_args}."
+    if missing_args:
+        raise RuntimeError(f"Function `{func.__name__}()` is missing following required args: {missing_args}.")
 
 def dfs_task(dfs_subject:Any,
              adj_func:Callable[[Any], Iterable],
@@ -180,7 +184,7 @@ def data_repr(val:Any):
         return item_repr(val_type, val)
 
 class Timer(Status):
-    def __init__(self, /, task_desc:str,
+    def __init__(self, task_desc:str,
                  *args, **kwargs):
         super(Timer, self).__init__(status=task_desc, *args, **kwargs)
         self.task_desc = task_desc

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -3,7 +3,7 @@ import sys
 from rich import print
 from inspect import signature
 from functools import partial
-from typing import Any, Callable, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
 
 def perfect_savepath(origin_path:str, 
                      target_ext:Optional[str],
@@ -154,6 +154,48 @@ def dfs_task(dfs_subject:Any,
                      visited=visited)
     
     return task_res
+
+def indent_str(s:Union[str, Sequence[str]], 
+               indent:int=4, 
+               guideline:bool=True,
+               process_first:bool=True) -> str:
+    res = []
+    split_lines = s.split('\n') if isinstance(s, str) else s
+    guideline = False if len(split_lines) == 1 else guideline
+    
+    for line in split_lines:
+        indent_line = '│' if guideline else ' ' 
+        indent_line += ' '*(indent-1) + str(line)
+        res.append(indent_line)
+
+    if not process_first:
+        res[0] = res[0][indent:]
+
+    if guideline:
+        res[-1] = '└─' + res[-1][2:]
+    
+    return '\n'.join(res)
+
+def data_repr(val:Any):
+    get_type = lambda val: type(val).__name__
+
+    item_repr = lambda val_type, val: (f"[dim]Shape[/]([b green]{list(val.shape)}[/])" if hasattr(val, 'shape') else f"[b green]{val}[/]") + f" [dim]<{val_type}>[/]"
+
+    val_type = get_type(val)
+    if isinstance(val, (list, tuple, set, dict)) and len(val) > 0:
+        if isinstance(val, dict):
+            inner_repr:List[str] = [f'{item_repr(get_type(k),k)}: {data_repr(v)}' for k, v in val.items()]
+        else:
+            inner_repr:List[str] = [data_repr(i) for i in val]
+        
+        res_repr = f'[dim]{val_type}[/](' 
+        res_repr += ',\n'.join(inner_repr)
+        res_repr += ')'
+
+        return indent_str(res_repr, indent=len(f'{val_type}('), process_first=False)
+    
+    else:
+        return item_repr(val_type, val)
 
 class Verboser:
     def __init__(self, 

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -1,29 +1,32 @@
 import os
-import sys
 from time import perf_counter
 from inspect import signature
 from functools import partial
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, List, Sequence, Tuple, Union
 
 from rich.status import Status
 
-def perfect_savepath(origin_path:str, 
-                     target_ext:Optional[str],
+def resolve_savepath(origin_path:str, 
+                     target_ext:str,
                      default_filename:str='Data'):
     origin_path = os.path.abspath(origin_path)
     dir, file = os.path.split(origin_path)
-    if '.' in file: # specify a file path
+    
+    # origin_path is a file path
+    if '.' in file: 
         os.makedirs(dir, exist_ok=True)
         save_dir = dir
         save_file = os.path.join(dir, os.path.splitext(file)[0]+f".{target_ext}")
-    else: # specify a dir path
+    
+    # origin_path is a dir path
+    else: 
         os.makedirs(origin_path, exist_ok=True)
         save_dir = origin_path
         save_file = os.path.join(origin_path, f"{default_filename}.{target_ext}")
     
     return save_dir, save_file
 
-def check_args(func:Callable, *required_args:Tuple[str]) -> List:
+def hasargs(func:Callable, *required_args:Tuple[str]) -> None:
     """
     Check if the function `func` has all the required arguments.
 
@@ -34,32 +37,15 @@ def check_args(func:Callable, *required_args:Tuple[str]) -> List:
 
     Returns:
     ---
-        List: A list containing names of missing arguments.
-    
-    Example:
-    ---
-    ```python
-    def test_func(a, bb, c_c, d9):
-        pass
-
-    check_args(test_func, 'a', 'bb', 'c_c', 'd9') 
-    # >>> []
-
-    check_args(test_func, 'A', 'e') 
-    # >>> ['A', 'e']
-    ```
+        None
     """
     if not required_args:
-        return []
+        return 
         
     missing_args = [arg for arg in required_args 
                         if arg not in signature(func).parameters]
-    if missing_args:
-        print(f"[bold red]Missing following args in function `{func.__name__}()`:[/]")
-        for arg in missing_args:
-            print(f"[red][-] [bold]`{arg}`[/]")
     
-    return missing_args
+    assert not missing_args, f"Function `{func.__name__}()` is missing follewing required args: {missing_args}."
 
 def dfs_task(dfs_subject:Any,
              adj_func:Callable[[Any], Iterable],
@@ -134,13 +120,7 @@ def dfs_task(dfs_subject:Any,
         ```
     """
     
-    missing_args = check_args(task_func, 'subject', 'pre_res')
-    if missing_args:
-        print(f"[bold red]Argument `task_func` of `{dfs_task.__name__}()` should be passed in a function with two parameters:")
-        print('[bold red]1. [magenta]`subject`[/magenta]: the first argument, used to receive the currently traversed object[/]')
-        print('[bold red]2. [magenta]`pre_res`[/magenta]: the second argument, used to receive the result of the previous level task[/]')
-        sys.exit(1)
-    del missing_args
+    hasargs(task_func, 'subject', 'pre_res')
 
     visited_signal = visited_signal_func(dfs_subject)
     

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -50,7 +50,7 @@ def hasargs(func:Callable, *required_args:Tuple[str]) -> None:
 def dfs_task(dfs_subject:Any,
              adj_func:Callable[[Any], Iterable],
              task_func:Callable[[Any, Any], Any],
-             visited_signal_func:Callable[[Any], Any]=lambda x:x,
+             visited_signal_func:Callable[[Any], Any]=lambda x:id(x),
              *,
              visited:List=[]) -> Any: 
     """

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -1,9 +1,11 @@
 import os
 import sys
-from rich import print
+from time import perf_counter
 from inspect import signature
 from functools import partial
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
+
+from rich.status import Status
 
 def perfect_savepath(origin_path:str, 
                      target_ext:Optional[str],
@@ -197,42 +199,18 @@ def data_repr(val:Any):
     else:
         return item_repr(val_type, val)
 
-class Verboser:
-    def __init__(self, 
-                 enable:bool=True, 
-                 enter_text:str='',
-                 enter_args:dict={},
-                 exit_text:str='',
-                 exit_args:dict={}):
-        """
-        A context manager to print specific text when entering and exiting the context.
-
-        Args:
-        ---
-            - `enable` (bool, optional): Whether to enable the functionality. Defaults to True.
-            
-            - `enter_text` (str, optional): The text to print when entering the context. Defaults to ''.
-            
-            - `enter_args` (dict, optional): The arguments to pass to `rich.print()` when entering the manager. Defaults to {}.
-            
-            - `exit_text` (str, optional): The text to print when exiting the context. Defaults to ''.
-            
-            - `exit_args` (dict, optional): The arguments to pass to `rich.print()` when exiting the manager. Defaults to {}.
-        """
-        self.enable = enable
-        
-        self.enter_text = enter_text
-        self.enter_args = enter_args
-        
-        self.exit_text = exit_text
-        self.exit_args = exit_args
+class Timer(Status):
+    def __init__(self, /, task_desc:str,
+                 *args, **kwargs):
+        super(Timer, self).__init__(status=task_desc, *args, **kwargs)
+        self.task_desc = task_desc
     
     def __enter__(self):
-        if self.enable:
-            print(self.enter_text, **self.enter_args)
+        super().__enter__()
+        self.__start_time = perf_counter()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.enable:
-            print(self.exit_text, **self.exit_args)
-        return False
+        ellapsed_time = perf_counter() - self.__start_time
+        super().__exit__(exc_type, exc_val, exc_tb)
+        self.console.print(f"[b blue]Finish {self.task_desc} in [green]{ellapsed_time:.4f}[/green] seconds[/]")

--- a/torchmeter/utils.py
+++ b/torchmeter/utils.py
@@ -13,11 +13,11 @@ def perfect_savepath(origin_path:str,
     if '.' in file: # specify a file path
         os.makedirs(dir, exist_ok=True)
         save_dir = dir
-        save_file = os.path.join(dir, os.path.splitext(file)[0]+f'.{target_ext}')
+        save_file = os.path.join(dir, os.path.splitext(file)[0]+f".{target_ext}")
     else: # specify a dir path
         os.makedirs(origin_path, exist_ok=True)
         save_dir = origin_path
-        save_file = os.path.join(origin_path, f'{default_filename}.{target_ext}')
+        save_file = os.path.join(origin_path, f"{default_filename}.{target_ext}")
     
     return save_dir, save_file
 
@@ -53,9 +53,9 @@ def check_args(func:Callable, *required_args:Tuple[str]) -> List:
     missing_args = [arg for arg in required_args 
                         if arg not in signature(func).parameters]
     if missing_args:
-        print(f'[bold red]Missing following args in function `{func.__name__}()`:[/]')
+        print(f"[bold red]Missing following args in function `{func.__name__}()`:[/]")
         for arg in missing_args:
-            print(f'[red][-] [bold]`{arg}`[/]')
+            print(f"[red][-] [bold]`{arg}`[/]")
     
     return missing_args
 
@@ -134,7 +134,7 @@ def dfs_task(dfs_subject:Any,
     
     missing_args = check_args(task_func, 'subject', 'pre_res')
     if missing_args:
-        print(f'[bold red]Argument `task_func` of `{dfs_task.__name__}()` should be passed in a function with two parameters:')
+        print(f"[bold red]Argument `task_func` of `{dfs_task.__name__}()` should be passed in a function with two parameters:")
         print('[bold red]1. [magenta]`subject`[/magenta]: the first argument, used to receive the currently traversed object[/]')
         print('[bold red]2. [magenta]`pre_res`[/magenta]: the second argument, used to receive the result of the previous level task[/]')
         sys.exit(1)
@@ -184,15 +184,15 @@ def data_repr(val:Any):
     val_type = get_type(val)
     if isinstance(val, (list, tuple, set, dict)) and len(val) > 0:
         if isinstance(val, dict):
-            inner_repr:List[str] = [f'{item_repr(get_type(k),k)}: {data_repr(v)}' for k, v in val.items()]
+            inner_repr:List[str] = [f"{item_repr(get_type(k),k)}: {data_repr(v)}" for k, v in val.items()]
         else:
             inner_repr:List[str] = [data_repr(i) for i in val]
         
-        res_repr = f'[dim]{val_type}[/](' 
+        res_repr = f"[dim]{val_type}[/]("
         res_repr += ',\n'.join(inner_repr)
         res_repr += ')'
 
-        return indent_str(res_repr, indent=len(f'{val_type}('), process_first=False)
+        return indent_str(res_repr, indent=len(f"{val_type}("), process_first=False)
     
     else:
         return item_repr(val_type, val)


### PR DESCRIPTION
## 📋 Summary

> [!IMPORTANT]
> - [ ] This PR fixes an issue. [Link]() <!--Link to related issues if applicable -->    
> - [x] This PR adds something new.
> - [ ] This PR is **not** a code change (e.g. `README`, typos, ...)
> - [ ] This PR has been tested.

<!-- What is this pull request for? Does it fix any issues? -->

## 📝 Changes

<!-- Describe what you change and what the purpose in this pull request. -->

<details>
<summary>Details</summary>

- `default_cfg.yaml`: the universal display setting with fine-grade comment.
- `torchmeter/config.py`: Use a global instance following the singleton pattern to manage the display of trees and tables.
- `torchmeter/core.py`: fix bugs, implemented caching for the render tree and added practical functions to `Meter` class, such as `_ipt2device()`, `_is_ipt_empty()`, etc.
- `torchmeter/display.py`: compatiable with low version of `rich`, cancel the exposure of backend dataframe, and add `exclude_cols` in table rendering.
- `torchmeter/engine.py`: organized the code to make the implementation more elegant.
- `torchmeter/statistic.py`: fix bugs to deal with the modules which might be not called explicitly, or duplicated accessed, or operation data inplace. Additionally, fix the bugs that multiple input or output can't be displayed, also rectify some measuring logit error in differernt statistics.
- `torchmeter/unit.py`: discard `DecimalUnit`; fix the bug in `auto_unit()`. The bug is about how to display a value when it's too small to find a unit.
- `torchmeter/utils.py`: move `data_repr` and `indent_str` here, and rewrite `Verboser` as the more elegant `Timer`.

</details>